### PR TITLE
Fix bug with tlsSkipVerify and add test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,17 @@ jobs:
           test secret | NAMED_SECRET ;
           nested/test otherSecret ;
 
+    - name: Test Vault Action (tlsSkipVerify)
+      uses: ./
+      with:
+        url: https://localhost:8200
+        token: ${{ env.VAULT_TOKEN }}
+        tlsSkipVerify: true
+        clientCertificate: ${{ secrets.VAULT_CLIENT_CERT }}
+        clientKey: ${{ secrets.VAULT_CLIENT_KEY }}
+        secrets: |
+          tlsSkipVerify skip ;
+
     - name: Test Vault Action (default KV V1)
       uses: ./
       with:
@@ -255,7 +266,7 @@ jobs:
 
 # Removing publish step for now.
 #  publish:
-#    if: github.event_name	== 'push' && contains(github.ref, 'master')
+
 #    runs-on: ubuntu-latest
 #    needs: [build, integration, e2e]
 #    steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
 
 # Removing publish step for now.
 #  publish:
-
+#    if: github.event_name	== 'push' && contains(github.ref, 'master')
 #    runs-on: ubuntu-latest
 #    needs: [build, integration, e2e]
 #    steps:

--- a/dist/index.js
+++ b/dist/index.js
@@ -14128,7 +14128,7 @@ async function exportSecrets() {
 
     const tlsSkipVerify = (core.getInput('tlsSkipVerify', { required: false }) || 'false').toLowerCase() != 'false';
     if (tlsSkipVerify === true) {
-        defaultOptions.https.rejectUnauthorized = true;
+        defaultOptions.https.rejectUnauthorized = false;
     }
 
     const caCertificateRaw = core.getInput('caCertificate', { required: false });

--- a/integrationTests/e2e-tls/e2e-tls.test.js
+++ b/integrationTests/e2e-tls/e2e-tls.test.js
@@ -9,5 +9,6 @@ describe('e2e-tls', () => {
         expect(process.env.OTHERALTSECRET).toBe("OTHERCUSTOMSECRET");
         expect(process.env.FOO).toBe("bar");
         expect(process.env.NAMED_CUBBYSECRET).toBe("zap");
+        expect(process.env.SKIP).toBe("true");
     });
 });

--- a/integrationTests/e2e-tls/setup.js
+++ b/integrationTests/e2e-tls/setup.js
@@ -113,6 +113,23 @@ const clientKeyRaw = `${process.env.VAULT_CLIENT_KEY}`;
             }
         });
 
+        await got(`https://${vaultUrl}/v1/secret/data/tlsSkipVerify`, {
+            method: 'POST',
+            headers: {
+                'X-Vault-Token': rootToken,
+            },
+            https: {
+                certificateAuthority: caCertificate,
+                certificate: clientCertificate,
+                key: clientKey,
+            },
+            json: {
+                data: {
+                    skip: 'true',
+                },
+            }
+        });
+
         await got(`https://${vaultUrl}/v1/sys/mounts/my-secret`, {
             method: 'POST',
             headers: {

--- a/src/action.js
+++ b/src/action.js
@@ -35,7 +35,7 @@ async function exportSecrets() {
 
     const tlsSkipVerify = (core.getInput('tlsSkipVerify', { required: false }) || 'false').toLowerCase() != 'false';
     if (tlsSkipVerify === true) {
-        defaultOptions.https.rejectUnauthorized = true;
+        defaultOptions.https.rejectUnauthorized = false;
     }
 
     const caCertificateRaw = core.getInput('caCertificate', { required: false });


### PR DESCRIPTION
A bug with `tlsSkipVerify` introduced in #97 wouldn't allow users to disable the verification of Vault's certificate.  This fixes that bug and adds missing test coverage on this parameter which would have caught this bug.