### PR TITLE
Simplify secret request UX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,9 +151,9 @@ jobs:
         url: http://localhost:8200
         token: testtoken
         secrets: |
-          secret/data/test altSecret ;
-          secret/data/test altSecret | NAMED_ALTSECRET ;
-          secret/data/nested/test otherAltSecret ;
+          my-secret/test altSecret ;
+          my-secret/test altSecret | NAMED_ALTSECRET ;
+          my-secret/nested/test otherAltSecret ;
 
     - name: Test Vault Action (cubbyhole)
       uses: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,21 +141,19 @@ jobs:
         url: http://localhost:8200
         token: testtoken
         secrets: |
-          test secret ;
-          test secret | NAMED_SECRET ;
-          nested/test otherSecret ;
+          secret/data/test secret ;
+          secret/data/test secret | NAMED_SECRET ;
+          secret/data/nested/test otherSecret ;
 
     - name: Test Vault Action (default KV V1)
       uses: ./
       with:
         url: http://localhost:8200
         token: testtoken
-        path: my-secret
-        kv-version: 1
         secrets: |
-          test altSecret ;
-          test altSecret | NAMED_ALTSECRET ;
-          nested/test otherAltSecret ;
+          secret/data/test altSecret ;
+          secret/data/test altSecret | NAMED_ALTSECRET ;
+          secret/data/nested/test otherAltSecret ;
 
     - name: Test Vault Action (cubbyhole)
       uses: ./
@@ -217,9 +215,9 @@ jobs:
         clientCertificate: ${{ secrets.VAULT_CLIENT_CERT }}
         clientKey: ${{ secrets.VAULT_CLIENT_KEY }}
         secrets: |
-          test secret ;
-          test secret | NAMED_SECRET ;
-          nested/test otherSecret ;
+          secret/data/test secret ;
+          secret/data/test secret | NAMED_SECRET ;
+          secret/data/nested/test otherSecret ;
 
     - name: Test Vault Action (tlsSkipVerify)
       uses: ./
@@ -230,22 +228,20 @@ jobs:
         clientCertificate: ${{ secrets.VAULT_CLIENT_CERT }}
         clientKey: ${{ secrets.VAULT_CLIENT_KEY }}
         secrets: |
-          tlsSkipVerify skip ;
+          secret/data/tlsSkipVerify skip ;
 
     - name: Test Vault Action (default KV V1)
       uses: ./
       with:
         url: https://localhost:8200
         token: ${{ env.VAULT_TOKEN }}
-        path: my-secret
-        kv-version: 1
         caCertificate: ${{ secrets.VAULTCA }}
         clientCertificate: ${{ secrets.VAULT_CLIENT_CERT }}
         clientKey: ${{ secrets.VAULT_CLIENT_KEY }}
         secrets: |
-          test altSecret ;
-          test altSecret | NAMED_ALTSECRET ;
-          nested/test otherAltSecret ;
+          my-secret/test altSecret ;
+          my-secret/test altSecret | NAMED_ALTSECRET ;
+          my-secret/nested/test otherAltSecret ;
 
     - name: Test Vault Action (cubbyhole)
       uses: ./

--- a/action.yml
+++ b/action.yml
@@ -10,13 +10,6 @@ inputs:
   namespace:
     description: 'The Vault namespace from which to query secrets. Vault Enterprise only, unset by default'
     required: false
-  path:
-    description: 'The path of a non-default K/V engine'
-    required: false
-  kv-version:
-    description: 'The version of the K/V engine to use.'
-    default: '2'
-    required: false
   method:
     description: 'The method to use to authenticate with Vault.'
     default: 'token'

--- a/integrationTests/basic/integration.test.js
+++ b/integrationTests/basic/integration.test.js
@@ -7,7 +7,7 @@ const { when } = require('jest-when');
 
 const { exportSecrets } = require('../../src/action');
 
-const vaultUrl = `http://${process.env.VAULT_HOST || 'localhost'}:${process.env.VAULT_PORT || '8200'}`;
+const vaultUrl = `http://${process.env.VAULT_HOST || '0.0.0.0'}:${process.env.VAULT_PORT || '8200'}`;
 
 describe('integration', () => {
     beforeAll(async () => {
@@ -42,9 +42,21 @@ describe('integration', () => {
             }
         });
 
+        await got(`${vaultUrl}/v1/secret/data/foobar`, {
+            method: 'POST',
+            headers: {
+                'X-Vault-Token': 'testtoken',
+            },
+            json: {
+                data: {
+                    fookv2: 'bar',
+                },
+            }
+        });
+
         // Enable custom secret engine
         try {
-            await got(`${vaultUrl}/v1/sys/mounts/my-secret`, {
+            await got(`${vaultUrl}/v1/sys/mounts/secret-kv1`, {
                 method: 'POST',
                 headers: {
                     'X-Vault-Token': 'testtoken',
@@ -62,7 +74,7 @@ describe('integration', () => {
             }
         }
 
-        await got(`${vaultUrl}/v1/my-secret/test`, {
+        await got(`${vaultUrl}/v1/secret-kv1/test`, {
             method: 'POST',
             headers: {
                 'X-Vault-Token': 'testtoken',
@@ -72,7 +84,17 @@ describe('integration', () => {
             }
         });
 
-        await got(`${vaultUrl}/v1/my-secret/nested/test`, {
+        await got(`${vaultUrl}/v1/secret-kv1/foobar`, {
+            method: 'POST',
+            headers: {
+                'X-Vault-Token': 'testtoken',
+            },
+            json: {
+                fookv1: 'bar',
+            }
+        });
+
+        await got(`${vaultUrl}/v1/secret-kv1/nested/test`, {
             method: 'POST',
             headers: {
                 'X-Vault-Token': 'testtoken',
@@ -101,20 +123,8 @@ describe('integration', () => {
             .mockReturnValueOnce(secrets);
     }
 
-    function mockEngineName(name) {
-        when(core.getInput)
-            .calledWith('path')
-            .mockReturnValueOnce(name);
-    }
-
-    function mockVersion(version) {
-        when(core.getInput)
-            .calledWith('kv-version')
-            .mockReturnValueOnce(version);
-    }
-
     it('get simple secret', async () => {
-        mockInput('test secret');
+        mockInput('secret/data/test secret');
 
         await exportSecrets();
 
@@ -122,7 +132,7 @@ describe('integration', () => {
     });
 
     it('re-map secret', async () => {
-        mockInput('test secret | TEST_KEY');
+        mockInput('secret/data/test secret | TEST_KEY');
 
         await exportSecrets();
 
@@ -130,7 +140,7 @@ describe('integration', () => {
     });
 
     it('get nested secret', async () => {
-        mockInput('nested/test otherSecret');
+        mockInput('secret/data/nested/test otherSecret');
 
         await exportSecrets();
 
@@ -139,9 +149,9 @@ describe('integration', () => {
 
     it('get multiple secrets', async () => {
         mockInput(`
-        test secret ;
-        test secret | NAMED_SECRET ;
-        nested/test otherSecret ;`);
+        secret/data/test secret ;
+        secret/data/test secret | NAMED_SECRET ;
+        secret/data/nested/test otherSecret ;`);
 
         await exportSecrets();
 
@@ -152,10 +162,16 @@ describe('integration', () => {
         expect(core.exportVariable).toBeCalledWith('OTHERSECRET', 'OTHERSUPERSECRET');
     });
 
+    it('leading slash kvv2', async () => {
+        mockInput('/secret/data/foobar fookv2');
+
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledWith('FOOKV2', 'bar');
+    });
+
     it('get secret from K/V v1', async () => {
-        mockInput('test secret');
-        mockEngineName('my-secret');
-        mockVersion('1');
+        mockInput('secret-kv1/test secret');
 
         await exportSecrets();
 
@@ -163,13 +179,19 @@ describe('integration', () => {
     });
 
     it('get nested secret from K/V v1', async () => {
-        mockInput('nested/test otherSecret');
-        mockEngineName('my-secret');
-        mockVersion('1');
+        mockInput('secret-kv1/nested/test otherSecret');
 
         await exportSecrets();
 
         expect(core.exportVariable).toBeCalledWith('OTHERSECRET', 'OTHERCUSTOMSECRET');
+    });
+
+    it('leading slash kvv1', async () => {
+        mockInput('/secret-kv1/foobar fookv1');
+
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledWith('FOOKV1', 'bar');
     });
 
     describe('generic engines', () => {

--- a/integrationTests/basic/integration.test.js
+++ b/integrationTests/basic/integration.test.js
@@ -7,7 +7,7 @@ const { when } = require('jest-when');
 
 const { exportSecrets } = require('../../src/action');
 
-const vaultUrl = `http://${process.env.VAULT_HOST || '0.0.0.0'}:${process.env.VAULT_PORT || '8200'}`;
+const vaultUrl = `http://${process.env.VAULT_HOST || 'localhost'}:${process.env.VAULT_PORT || '8200'}`;
 
 describe('integration', () => {
     beforeAll(async () => {

--- a/integrationTests/enterprise/enterprise.test.js
+++ b/integrationTests/enterprise/enterprise.test.js
@@ -56,7 +56,7 @@ describe('integration', () => {
     });
 
     it('get simple secret', async () => {
-        mockInput('test secret');
+        mockInput('secret/data/test secret');
 
         await exportSecrets();
 
@@ -64,7 +64,7 @@ describe('integration', () => {
     });
 
     it('re-map secret', async () => {
-        mockInput('test secret | TEST_KEY');
+        mockInput('secret/data/test secret | TEST_KEY');
 
         await exportSecrets();
 
@@ -72,7 +72,7 @@ describe('integration', () => {
     });
 
     it('get nested secret', async () => {
-        mockInput('nested/test otherSecret');
+        mockInput('secret/data/nested/test otherSecret');
 
         await exportSecrets();
 
@@ -81,9 +81,9 @@ describe('integration', () => {
 
     it('get multiple secrets', async () => {
         mockInput(`
-        test secret ;
-        test secret | NAMED_SECRET ;
-        nested/test otherSecret ;`);
+        secret/data/test secret ;
+        secret/data/test secret | NAMED_SECRET ;
+        secret/data/nested/test otherSecret ;`);
 
         await exportSecrets();
 
@@ -95,9 +95,7 @@ describe('integration', () => {
     });
 
     it('get secret from K/V v1', async () => {
-        mockInput('test secret');
-        mockEngineName('my-secret');
-        mockVersion('1');
+        mockInput('my-secret/test secret');
 
         await exportSecrets();
 
@@ -105,9 +103,7 @@ describe('integration', () => {
     });
 
     it('get nested secret from K/V v1', async () => {
-        mockInput('nested/test otherSecret');
-        mockEngineName('my-secret');
-        mockVersion('1');
+        mockInput('my-secret/nested/test otherSecret');
 
         await exportSecrets();
 
@@ -229,7 +225,7 @@ describe('authenticate with approle', () => {
     });
 
     it('authenticate with approle', async() => {
-        mockInput('test secret');
+        mockInput('secret/data/test secret');
 
         await exportSecrets();
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -25,9 +25,9 @@ async function getSecrets(secretRequests, client) {
     const responseCache = new Map();
     const results = [];
     for (const secretRequest of secretRequests) {
-        const { path, selector } = secretRequest;
+        let { path, selector } = secretRequest;
 
-        const requestPath = `v1${path}`;
+        const requestPath = `v1/${path}`;
         let body;
         let cachedResponse = false;
         if (responseCache.has(requestPath)) {
@@ -39,7 +39,13 @@ async function getSecrets(secretRequests, client) {
             responseCache.set(requestPath, body);
         }
 
-        const value = selectData(JSON.parse(body), selector);
+        selector = "data." + selector
+        body = JSON.parse(body)
+        if (body.data["data"] != undefined) {
+            selector = "data." + selector
+        }
+
+        const value = selectData(body, selector);
         results.push({
             request: secretRequest,
             value,


### PR DESCRIPTION
## Overview

This makes a backwards incompatible change to the UX for requesting secrets from Vault.  Changing the UX in a required way is not something I take lightly but I believe now is the best time to get this right.

This change makes requesting secrets more explicit by requiring the full path of the secret, rather than configuring extra parameters such as `path` and `kv-version`.  By being more explicit with the secret path, mixing secret engines is possible and there are less parameters to configure.

Additionally I added a bit of logic to unpack responses from Vault data smarter (instead of relying on parameters to change the selector logic).

New UX:

```yaml
- name: Import Secrets
   uses: hashicorp/vault-action
   with:
     url: https://vault.mycompany.com:8200
     token: ${{ secrets.VaultToken }}
     secrets: |
         aws/ci/app accessKey | AWS_ACCESS_KEY_ID ;
         aws/ci/app secretKey | AWS_SECRET_ACCESS_KEY ;
         my-secret/data/ci npm_token
```

Old UX:

```yaml
- name: Import Secrets
   uses: hashicorp/vault-action
   with:
     url: https://vault.mycompany.com:8200
     token: ${{ secrets.VaultToken }}
     path: "aws"
     kv-version: 1
     secrets: |
         ci/app accessKey | AWS_ACCESS_KEY_ID ;
         ci/app secretKey | AWS_SECRET_ACCESS_KEY ;
         /my-secret/data/ci npm_token
```

## Testing

To execute the unit tests, run the following commands:

```bash
$ docker-compose up -d vault
$ npm run build
$ npm install
$ ./node_modules/jest/bin/jest.js -c integrationTests/basic/jest.config.js
```

The e2e tests are currently done via a GitHub workflow and cannot be run locally.  These will be moved to local integration tests and executed by the workflow in the future.
