### PR TITLE
Update Jira sync action versions

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -47,12 +47,12 @@ jobs:
         fi
     - name: Create ticket
       if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
-      uses: tomhjp/gh-action-jira-create@v0.1.0
+      uses: tomhjp/gh-action-jira-create@v0.1.3
       with:
         project: VAULT
         issuetype: "GH Issue"
         summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
-        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }}, from ${{ github.actor }}_"
+        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
         # customfield_10089 is Issue Link custom field
         # customfield_10091 is team custom field
         extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["ecosystem"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
@@ -67,7 +67,7 @@ jobs:
 
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: atlassian/gajira-comment@v2.0.1
+      uses: tomhjp/gh-action-jira-comment@v0.1.0
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"


### PR DESCRIPTION
These versions bring a few fixes:
* The action now supports converting the most common bits of markdown syntax into Jira formatting directives
* Replaces Atlassian's comment action, which tries to interpolate bits of text from comments wrapped in {{ github.event_name }} as templates, usually causing an error (in the case I've put there, if I wasn't a vault team member, it would replace the template with `pull_request_target`)
* Remove trailing comma after link that broke the link target Jira selects