### PR TITLE
specify version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
         steps:
             # ...
             - name: Import Secrets
-              uses: hashicorp/vault-action
+              uses: hashicorp/vault-action@v2.0.0
               with:
                 url: https://vault.mycompany.com:8200
                 token: ${{ secrets.VaultToken }}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
         steps:
             # ...
             - name: Import Secrets
-              uses: hashicorp/vault-action@v2.0.0
+              uses: hashicorp/vault-action@v2.0.1
               with:
                 url: https://vault.mycompany.com:8200
                 token: ${{ secrets.VaultToken }}


### PR DESCRIPTION
Without specifying `@v2.0.0` GitHub says the string is not the correct format

``` 
The workflow is not valid. .github/workflows/integration_tests.yml (Line: 10, Col: 15): Expected format {org}/{repo}[/path]@ref. Actual 'hashicorp/vault-action',Input string was not in a correct format.
```