### PR TITLE
Add pull_request_target to build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - master
+  pull_request_target:
+    types: [opened, closed, reopened]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,10 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
   pull_request_target:
     types: [opened, closed, reopened]
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Community PRs don't have access to the set GitHub secrets that have the e2e-tls certificate and key required for setup of Vault. This changes the action to run against the base of the PR and access the secrets we've set.