### PR TITLE
Write a better error message when secret not found

### DIFF
--- a/integrationTests/basic/integration.test.js
+++ b/integrationTests/basic/integration.test.js
@@ -123,6 +123,14 @@ describe('integration', () => {
             .mockReturnValueOnce(secrets);
     }
 
+    it('prints a nice error message when secret not found', async () => {
+        mockInput(`secret/data/test secret ;
+        secret/data/test secret | NAMED_SECRET ;
+        secret/data/notFound kehe | NO_SIR ;`);
+
+        expect(exportSecrets()).rejects.toEqual(Error(`Unable to retrieve result for "secret/data/notFound". Double check your Key.`));
+    })
+
     it('get simple secret', async () => {
         mockInput('secret/data/test secret');
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -34,9 +34,17 @@ async function getSecrets(secretRequests, client) {
             body = responseCache.get(requestPath);
             cachedResponse = true;
         } else {
-            const result = await client.get(requestPath);
-            body = result.body;
-            responseCache.set(requestPath, body);
+            try {
+                const result = await client.get(requestPath);
+                body = result.body;
+                responseCache.set(requestPath, body);
+            } catch (error) {
+                const {response} = error;
+                if (response.statusCode === 404) {
+                    throw Error(`Unable to retrieve result for "${path}". Double check your Key.`)
+                }
+                throw error
+            }
         }
         if (!selector.match(/.*[\.].*/)) {
             selector = '"' + selector + '"'


### PR DESCRIPTION
Currently when a secret is not found we get an error message

```
Response code 404 (Not Found)
```

If you have multiple secrets it can be tedious to figure out which secret is missing. 

This PR fixes that by giving the error message

```
Unable to retrieve result for "secret/data/notFound". Double check your Key.
```