### PR TITLE
Add GitHub authentication notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,19 @@ with:
   caCertificate: ${{ secrets.VAULTCA }}
 ```
 - **github**: you must provide the github token as `githubToken`
+
+**Notice: [Vault GitHub authentication](https://www.vaultproject.io/docs/auth/github)
+requires `org:read` permissions for authentication. The auto-generated `GITHUB_TOKEN`
+created for projects does not have these permissions and GitHub does not allow this
+token's permissions to be modified. A new GitHub Token secret must be created with
+`org:read` permissions to use this authentication method.**
+
 ```yaml
 ...
 with:
   url: https://vault.mycompany.com:8200
   method: github
-  githubToken: ${{ secrets.GITHUB_TOKEN }}
+  githubToken: ${{ secrets.MY_GITHUB_TOKEN }}
   caCertificate: ${{ secrets.VAULTCA }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ with:
 - **github**: you must provide the github token as `githubToken`
 
 **Notice: [Vault GitHub authentication](https://www.vaultproject.io/docs/auth/github)
-requires `org:read` permissions for authentication. The auto-generated `GITHUB_TOKEN`
+requires `read:org` permissions for authentication. The auto-generated `GITHUB_TOKEN`
 created for projects does not have these permissions and GitHub does not allow this
 token's permissions to be modified. A new GitHub Token secret must be created with
-`org:read` permissions to use this authentication method.**
+`read:org` permissions to use this authentication method.**
 
 ```yaml
 ...


### PR DESCRIPTION
The auto-generated GH token on repositories does not work with Vault GH auth due to the lack of organization permissions. Adding a note about this in the README to clear up the confusion.