### PR TITLE
chore(deps): bump marked from 1.2.6 to 2.0.1 security reason

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9086,9 +9086,9 @@
       }
     },
     "marked": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.6.tgz",
-      "integrity": "sha512-7vVuSEZ8g/HH3hK/BH/+7u/NJj7x9VY4EHzujLDcqAQLiOUeFJYAsfSAyoWtR17lKrx7b08qyIno4lffwrzTaA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
       "dev": true
     },
     "marked-terminal": {
@@ -13877,7 +13877,7 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^3.0.0",
         "lodash": "^4.17.15",
-        "marked": "^1.0.0",
+        "marked": "^2.0.0",
         "marked-terminal": "^4.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",


### PR DESCRIPTION
Security dependencies issue for marked 1.0.0 versions. 
[Link](https://snyk.io/vuln/SNYK-JS-MARKED-1070800) is available here