### PR TITLE
set vault license for enterprise tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,8 @@ jobs:
 
     - name: Run docker-compose
       run: docker-compose up -d vault-enterprise
+      env:
+        VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
 
     - uses: actions/setup-node@v1
       with:
@@ -93,7 +95,7 @@ jobs:
     - name: NPM Build
       run: npm run build
 
-    - name: NPM Run test:intergration:enterprise
+    - name: NPM Run test:integration:enterprise
       run: npm run test:integration:enterprise
       env:
         VAULT_HOST: localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: hashicorp/vault-enterprise:latest
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: testtoken
+      VAULT_LICENSE: ${VAULT_LICENSE_CI}
     ports:
       - 8200:8200
     privileged: true


### PR DESCRIPTION
Since `hashicorp/vault-enterprise:latest` now requires a license to do
anything, we need to set `$VAULT_LICENSE` when provisioning the
enterprise docker container.