### PR TITLE
feat(): add support for github provided jwt auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ with:
   githubToken: ${{ secrets.MY_GITHUB_TOKEN }}
   caCertificate: ${{ secrets.VAULTCA }}
 ```
-- **jwt**: you must provide a `role` & `jwtPrivateKey` parameters, additionally you can pass `jwtKeyPassword` & `jwtTtl` parameters
+- **jwt**: you must provide a `role` parameter, additionally you can pass `jwtPrivateKey`, `jwtKeyPassword` & `jwtTtl` parameters. 
+  Github provided JWT will be used if `jwtPrivateKey` was not specified
 ```yaml
 ...
 with:
@@ -96,6 +97,15 @@ with:
   jwtPrivateKey: ${{ secrets.JWT_PRIVATE_KEY }}
   jwtKeyPassword: ${{ secrets.JWT_KEY_PASS }}
   jwtTtl: 3600 # 1 hour, default value
+```
+
+**Notice:** In order for Github provided JWT to work workflow should have `id-token: write` specified in the `permissions` section  of a workflow
+
+```yaml
+...
+permissions:
+  id-token: write
+...
 ```
 
 - **kubernetes**: you must provide the `role` paramaters. You can optionally override the `kubernetesTokenPath` paramater for custom mounted serviceAccounts. Consider [kubernetes auth](https://www.vaultproject.io/docs/auth/kubernetes) when using self-hosted runners on Kubernetes:

--- a/dist/index.js
+++ b/dist/index.js
@@ -977,6 +977,7 @@ exports.default = parseBody;
 const core = __webpack_require__(470);
 const rsasign = __webpack_require__(758);
 const fs = __webpack_require__(747);
+const got = __webpack_require__(77).default;
 
 const defaultKubernetesTokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 /***
@@ -999,11 +1000,21 @@ async function retrieveToken(method, client) {
         }
         case 'jwt': {
             const role = core.getInput('role', { required: true });
-            const privateKeyRaw = core.getInput('jwtPrivateKey', { required: true });
+            const privateKeyRaw = core.getInput('jwtPrivateKey', { required: false });
             const privateKey = Buffer.from(privateKeyRaw, 'base64').toString();
             const keyPassword = core.getInput('jwtKeyPassword', { required: false });
             const tokenTtl = core.getInput('jwtTtl', { required: false }) || '3600'; // 1 hour
-            const jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
+            /** @type {string} */
+            let jwt;
+            const actionsIDTokenRequestToken = process.env['ACTIONS_ID_TOKEN_REQUEST_TOKEN'];
+            const actionsIDTokenRequestURL = process.env['ACTIONS_ID_TOKEN_REQUEST_URL'];
+
+            if (!privateKeyRaw && actionsIDTokenRequestToken && actionsIDTokenRequestURL) {
+                jwt = await getJwt(actionsIDTokenRequestToken, `${actionsIDTokenRequestURL}&audience=sigstore`);
+            } else {
+                jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
+            }
+
             return await getClientToken(client, method, path, { jwt: jwt, role: role });
         }
         case 'kubernetes': {
@@ -1058,6 +1069,34 @@ function generateJwt(privateKey, keyPassword, ttl) {
 }
 
 /***
+ * Call the appropriate endpoint and retrieves job's JWT
+ * @param {string} actionsIDTokenRequestToken
+ * @param {string} actionsIDTokenRequestURL
+ */
+async function getJwt(actionsIDTokenRequestToken, actionsIDTokenRequestURL) {
+    /** @type {'json'} */
+    const responseType = 'json';
+    const options = {
+        headers: {
+            Authorization: `Bearer ${actionsIDTokenRequestToken}`,
+        },
+        responseType,
+    };
+    const client = got.extend(options)
+
+    core.debug(`Retrieving Vault JWT from ${actionsIDTokenRequestURL} endpoint`);
+    /** @type {import('got').Response<GithubActionsIdTokenResponse>} */
+    const response = await client.get(actionsIDTokenRequestURL, options);
+
+    if (response && response.body && response.body.value) {
+        core.debug('✔ Github Actions ID Token successfully retrieved');
+        return response.body.value;
+    } else {
+        throw Error(`Unable to retrieve token from ${actionsIDTokenRequestURL}'s endpoint.`);
+    }
+}
+
+/***
  * Call the appropriate login endpoint and parse out the token in the response.
  * @param {import('got').Got} client
  * @param {string} method
@@ -1100,6 +1139,12 @@ async function getClientToken(client, method, path, payload) {
  *  lease_duration: number;
  *  renewable: boolean;
  * }} auth
+ */
+
+/***
+ * @typedef {Object} GithubActionsIdTokenResponse
+ * @property {string} value
+ * @property {string} count
  */
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13872,7 +13872,7 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^3.0.0",
         "lodash": "^4.17.15",
-        "marked": "^2.0.0",
+        "marked": "^1.0.0",
         "marked-terminal": "^4.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",


### PR DESCRIPTION
This PR add support for Github provided JWT

## Example Usage

```yaml
#...
jobs:
  # ...
  build:
    permissions:
      id-token: write
    steps:
      # ...
      - name: Import Secrets
        id: secrets
        uses: hashicorp/vault-action
        with:
          url: https://vault.mycompany.com:8200
          method: jwt
          role: github-action
          secrets: |
              secret/data/ci/aws accessKey | AWS_ACCESS_KEY_ID ;
              secret/data/ci/aws secretKey | AWS_SECRET_ACCESS_KEY
```

### Example Github provided JWT 
```
{
  "jti": "871e293a-7d48-466f-8f5f-e1713ae152cb",
  "sub": "repo:blz-ea/example-repo:ref:refs/heads/blz-ea-patch-1",
  "aud": "https://github.com/blz-ea/example-repo",
  "ref": "refs/heads/blz-ea-patch-1",
  "sha": "75829399ab789a6f927f6a7be1df283d4ee51e66",
  "repository": "blz-ea/example-repo",
  "repository_owner": "blz-ea",
  "run_id": "1262466604",
  "run_number": "19",
  "run_attempt": "2",
  "actor": "blz-ea",
  "workflow": "My Workflow Name",
  "head_ref": "",
  "base_ref": "",
  "event_name": "push",
  "ref_type": "branch",
  "job_workflow_ref": "blz-ea/example-repo/.github/workflows/test.yml@refs/heads/blz-ea-patch-1",
  "iss": "https://vstoken.actions.githubusercontent.com",
  "nbf": 1632324904,
  "exp": 1632325804,
  "iat": 1632325504
}
```


## Example JWT Auth Config
```json
{
  "jwt_validation_pubkeys" : [
    "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzW2j18tSka65aoPgmyk7\naUkYE7MmO8z9tM/HoKVJ+w/alYIknkf7pgBeWWfqRgkRfmDuJa8hATL20+bD9cQZ\n8uVAG1reQfIMxqxwt3DA6q37Co41NdgZ0MUTTQpfC0JyDbDwM/ZIzis1cQ1teJcr\nPBTQJ3TjvyBHeqDmEs2ZCmGLuHZloep8Y/4hmMBfMOFkz/7mWH7NPuhOLWnPTIKx\nnMuHl4EVdNL6CvIYEnzF24m/pf3IEM84vszL2s6+X7AbFheZVig8WqhEwiVjbUVx\nXcY4PtbK0z3jhgxcpjc6WTH0JlRedpq2ABowWZg+pxOoWZUAETfj6qBlbIn/F9kp\nyQIDAQAB\n-----END PUBLIC KEY-----"
  ],
  "bound_issuer": "https://vstoken.actions.githubusercontent.com"
}
```

### Example JWT Role
```json
{
  "role_type": "jwt",
  "bound_audiences": [ "sigstore" ],
  "policies": [
    "github-action"
  ],
  "token_explicit_max_ttl": 60,
  "bound_claims": {
    "repository": "*"
   },
  "subject_claim": "repository",
  "groups_claim": "sha",
  "user_claim": "actor",
  "bound_claims_type": "glob"
}
```

**Notice:** Based on unreleased Github feature