### PR TITLE
Log error messages on authentication errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1328,18 +1328,24 @@ async function getClientToken(client, method, path, payload) {
 
     core.debug(`Retrieving Vault Token from v1/auth/${path}/login endpoint`);
 
-    /** @type {import('got').Response<VaultLoginResponse>} */
-    const response = await client.post(`v1/auth/${path}/login`, options);
-    if (response && response.body && response.body.auth && response.body.auth.client_token) {
-        core.debug('✔ Vault Token successfully retrieved');
-
-        core.startGroup('Token Info');
-        core.debug(`Operating under policies: ${JSON.stringify(response.body.auth.policies)}`);
-        core.debug(`Token Metadata: ${JSON.stringify(response.body.auth.metadata)}`);
-        core.endGroup();
-
-        return response.body.auth.client_token;
-    } else {
+    
+    try {
+        /** @type {import('got').Response<VaultLoginResponse>} */
+        const response = await client.post(`v1/auth/${path}/login`, options);
+        if (response && response.body && response.body.auth && response.body.auth.client_token) {
+            core.debug('✔ Vault Token successfully retrieved');
+    
+            core.startGroup('Token Info');
+            core.debug(`Operating under policies: ${JSON.stringify(response.body.auth.policies)}`);
+            core.debug(`Token Metadata: ${JSON.stringify(response.body.auth.metadata)}`);
+            core.endGroup();
+    
+            return response.body.auth.client_token;
+        } else {
+            throw Error(`Unable to retrieve token from ${method}'s login endpoint.`);
+        }
+    } catch (error) {
+        core.debug(error.response.body);
         throw Error(`Unable to retrieve token from ${method}'s login endpoint.`);
     }
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -108,18 +108,24 @@ async function getClientToken(client, method, path, payload) {
 
     core.debug(`Retrieving Vault Token from v1/auth/${path}/login endpoint`);
 
-    /** @type {import('got').Response<VaultLoginResponse>} */
-    const response = await client.post(`v1/auth/${path}/login`, options);
-    if (response && response.body && response.body.auth && response.body.auth.client_token) {
-        core.debug('✔ Vault Token successfully retrieved');
-
-        core.startGroup('Token Info');
-        core.debug(`Operating under policies: ${JSON.stringify(response.body.auth.policies)}`);
-        core.debug(`Token Metadata: ${JSON.stringify(response.body.auth.metadata)}`);
-        core.endGroup();
-
-        return response.body.auth.client_token;
-    } else {
+    
+    try {
+        /** @type {import('got').Response<VaultLoginResponse>} */
+        const response = await client.post(`v1/auth/${path}/login`, options);
+        if (response && response.body && response.body.auth && response.body.auth.client_token) {
+            core.debug('✔ Vault Token successfully retrieved');
+    
+            core.startGroup('Token Info');
+            core.debug(`Operating under policies: ${JSON.stringify(response.body.auth.policies)}`);
+            core.debug(`Token Metadata: ${JSON.stringify(response.body.auth.metadata)}`);
+            core.endGroup();
+    
+            return response.body.auth.client_token;
+        } else {
+            throw Error(`Unable to retrieve token from ${method}'s login endpoint.`);
+        }
+    } catch (error) {
+        core.debug(error.response.body);
         throw Error(`Unable to retrieve token from ${method}'s login endpoint.`);
     }
 }


### PR DESCRIPTION
Since the got node-module throws an error on HTTP 400 we need to catch that to show the original error message from vault.

This should at least partly fix #273 