### PR TITLE
make "role" input optional

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -25,7 +25,7 @@ async function retrieveToken(method, client) {
         case 'jwt': {
             /** @type {string} */
             let jwt;
-            const role = core.getInput('role', { required: true });
+            const role = core.getInput('role', { required: false });
             const privateKeyRaw = core.getInput('jwtPrivateKey', { required: false });
             const privateKey = Buffer.from(privateKeyRaw, 'base64').toString();
             const keyPassword = core.getInput('jwtKeyPassword', { required: false });


### PR DESCRIPTION
Per Vault documentation it doesn't have to be provided,
and the auth provider's "default_role" parameter is required
precisely for this case.
https://www.vaultproject.io/api/auth/jwt