### PR TITLE
Fix tests from jest-when version bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,13 @@ on:
       - master
   pull_request_target:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - uses: actions/setup-node@v1
       with:

--- a/integrationTests/basic/integration.test.js
+++ b/integrationTests/basic/integration.test.js
@@ -109,17 +109,17 @@ describe('integration', () => {
         jest.resetAllMocks();
 
         when(core.getInput)
-            .calledWith('url')
+            .calledWith('url', expect.anything())
             .mockReturnValueOnce(`${vaultUrl}`);
 
         when(core.getInput)
-            .calledWith('token')
+            .calledWith('token', expect.anything())
             .mockReturnValueOnce('testtoken');
     });
 
     function mockInput(secrets) {
         when(core.getInput)
-            .calledWith('secrets')
+            .calledWith('secrets', expect.anything())
             .mockReturnValueOnce(secrets);
     }
 

--- a/integrationTests/basic/jwt_auth.test.js
+++ b/integrationTests/basic/jwt_auth.test.js
@@ -141,23 +141,23 @@ describe('jwt auth', () => {
             jest.resetAllMocks();
 
             when(core.getInput)
-                .calledWith('url')
+                .calledWith('url', expect.anything())
                 .mockReturnValueOnce(`${vaultUrl}`);
 
             when(core.getInput)
-                .calledWith('method')
+                .calledWith('method', expect.anything())
                 .mockReturnValueOnce('jwt');
 
             when(core.getInput)
-                .calledWith('jwtPrivateKey')
+                .calledWith('jwtPrivateKey', expect.anything())
                 .mockReturnValueOnce(privateRsaKeyBase64);
 
             when(core.getInput)
-                .calledWith('role')
+                .calledWith('role', expect.anything())
                 .mockReturnValueOnce('default');
 
             when(core.getInput)
-                .calledWith('secrets')
+                .calledWith('secrets', expect.anything())
                 .mockReturnValueOnce('secret/data/test secret');
         });
 
@@ -191,29 +191,29 @@ describe('jwt auth', () => {
             jest.resetAllMocks();
 
             when(core.getInput)
-                .calledWith('url')
+                .calledWith('url', expect.anything())
                 .mockReturnValueOnce(`${vaultUrl}`);
 
             when(core.getInput)
-                .calledWith('method')
+                .calledWith('method', expect.anything())
                 .mockReturnValueOnce('jwt');
 
             when(core.getInput)
-                .calledWith('jwtPrivateKey')
+                .calledWith('jwtPrivateKey', expect.anything())
                 .mockReturnValueOnce('');
 
             when(core.getInput)
-                .calledWith('secrets')
+                .calledWith('secrets', expect.anything())
                 .mockReturnValueOnce('secret/data/test secret');
         });
 
         it('successfully authenticates', async () => {
             when(core.getInput)
-                .calledWith('role')
+                .calledWith('role', expect.anything())
                 .mockReturnValueOnce('default');
 
             when(core.getIDToken)
-                .calledWith()
+                .calledWith(undefined)
                 .mockReturnValueOnce(defaultGithubJwt);
 
             await exportSecrets();
@@ -222,15 +222,15 @@ describe('jwt auth', () => {
 
         it('successfully authenticates with `jwtGithubAudience` set to `sigstore`', async () => {
             when(core.getInput)
-                .calledWith('role')
+                .calledWith('role', expect.anything())
                 .mockReturnValueOnce('default-sigstore');
 
             when(core.getInput)
-                .calledWith('jwtGithubAudience')
+                .calledWith('jwtGithubAudience', expect.anything())
                 .mockReturnValueOnce('sigstore');
 
             when(core.getIDToken)
-                .calledWith()
+                .calledWith(expect.anything())
                 .mockReturnValueOnce(mockGithubOIDCResponse('sigstore'));
 
             await exportSecrets();
@@ -239,11 +239,11 @@ describe('jwt auth', () => {
 
         it('successfully authenticates as default role without specifying it', async () => {
             when(core.getInput)
-                .calledWith('role')
+                .calledWith('role', expect.anything())
                 .mockReturnValueOnce(null);
 
             when(core.getIDToken)
-                .calledWith()
+                .calledWith(undefined)
                 .mockReturnValueOnce(defaultGithubJwt);
 
             await exportSecrets();

--- a/integrationTests/enterprise/enterprise.test.js
+++ b/integrationTests/enterprise/enterprise.test.js
@@ -43,15 +43,15 @@ describe('integration', () => {
         jest.resetAllMocks();
 
         when(core.getInput)
-            .calledWith('url')
+            .calledWith('url', expect.anything())
             .mockReturnValueOnce(`${vaultUrl}`);
 
         when(core.getInput)
-            .calledWith('token')
+            .calledWith('token', expect.anything())
             .mockReturnValueOnce('testtoken');
 
         when(core.getInput)
-            .calledWith('namespace')
+            .calledWith('namespace', expect.anything())
             .mockReturnValueOnce('ns1');
     });
 
@@ -211,16 +211,16 @@ describe('authenticate with approle', () => {
             .calledWith('method', expect.anything())
             .mockReturnValueOnce('approle');
         when(core.getInput)
-            .calledWith('roleId')
+            .calledWith('roleId', expect.anything())
             .mockReturnValueOnce(roleId);
         when(core.getInput)
-            .calledWith('secretId')
+            .calledWith('secretId', expect.anything())
             .mockReturnValueOnce(secretId);
         when(core.getInput)
-            .calledWith('url')
+            .calledWith('url', expect.anything())
             .mockReturnValueOnce(`${vaultUrl}`);
         when(core.getInput)
-            .calledWith('namespace')
+            .calledWith('namespace', expect.anything())
             .mockReturnValueOnce('ns2');
     });
 
@@ -286,18 +286,18 @@ async function writeSecret(engine, path, namespace, version, data) {
 
 function mockInput(secrets) {
     when(core.getInput)
-        .calledWith('secrets')
+        .calledWith('secrets', expect.anything())
         .mockReturnValueOnce(secrets);
 }
 
 function mockEngineName(name) {
     when(core.getInput)
-        .calledWith('path')
+        .calledWith('path', expect.anything())
         .mockReturnValueOnce(name);
 }
 
 function mockVersion(version) {
     when(core.getInput)
-        .calledWith('kv-version')
+        .calledWith('kv-version', expect.anything())
         .mockReturnValueOnce(version);
 }

--- a/integrationTests/enterprise/enterprise.test.js
+++ b/integrationTests/enterprise/enterprise.test.js
@@ -289,15 +289,3 @@ function mockInput(secrets) {
         .calledWith('secrets', expect.anything())
         .mockReturnValueOnce(secrets);
 }
-
-function mockEngineName(name) {
-    when(core.getInput)
-        .calledWith('path', expect.anything())
-        .mockReturnValueOnce(name);
-}
-
-function mockVersion(version) {
-    when(core.getInput)
-        .calledWith('kv-version', expect.anything())
-        .mockReturnValueOnce(version);
-}

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -94,7 +94,7 @@ describe('parseSecretsInput', () => {
 describe('parseHeaders', () => {
     it('parses simple header', () => {
         when(core.getInput)
-            .calledWith('extraHeaders')
+            .calledWith('extraHeaders', undefined)
             .mockReturnValueOnce('TEST: 1');
         const result = parseHeadersInput('extraHeaders');
         expect(Array.from(result)).toContainEqual(['test', '1']);
@@ -102,7 +102,7 @@ describe('parseHeaders', () => {
 
     it('parses simple header with whitespace', () => {
         when(core.getInput)
-            .calledWith('extraHeaders')
+            .calledWith('extraHeaders', undefined)
             .mockReturnValueOnce(`
             TEST: 1
             `);
@@ -112,7 +112,7 @@ describe('parseHeaders', () => {
 
     it('parses multiple headers', () => {
         when(core.getInput)
-            .calledWith('extraHeaders')
+            .calledWith('extraHeaders', undefined)
             .mockReturnValueOnce(`
             TEST: 1
             FOO: bAr
@@ -124,7 +124,7 @@ describe('parseHeaders', () => {
 
     it('parses null response', () => {
         when(core.getInput)
-            .calledWith('extraHeaders')
+            .calledWith('extraHeaders', undefined)
             .mockReturnValueOnce(null);
         const result = parseHeadersInput('extraHeaders');
         expect(Array.from(result)).toHaveLength(0);
@@ -136,29 +136,29 @@ describe('exportSecrets', () => {
         jest.resetAllMocks();
 
         when(core.getInput)
-            .calledWith('url')
+            .calledWith('url', expect.anything())
             .mockReturnValueOnce('http://vault:8200');
 
         when(core.getInput)
-            .calledWith('token')
+            .calledWith('token', expect.anything())
             .mockReturnValueOnce('EXAMPLE');
     });
 
     function mockInput(key) {
         when(core.getInput)
-            .calledWith('secrets')
+            .calledWith('secrets', expect.anything())
             .mockReturnValueOnce(key);
     }
 
     function mockVersion(version) {
         when(core.getInput)
-            .calledWith('kv-version')
+            .calledWith('kv-version', expect.anything())
             .mockReturnValueOnce(version);
     }
 
     function mockExtraHeaders(headerString) {
         when(core.getInput)
-            .calledWith('extraHeaders')
+            .calledWith('extraHeaders', expect.anything())
             .mockReturnValueOnce(headerString);
     }
 
@@ -181,7 +181,7 @@ describe('exportSecrets', () => {
 
     function mockExportToken(doExport) {
         when(core.getInput)
-            .calledWith('exportToken')
+            .calledWith('exportToken', expect.anything())
             .mockReturnValueOnce(doExport);
     }
 

--- a/src/auth.test.js
+++ b/src/auth.test.js
@@ -16,7 +16,7 @@ const {
 
 function mockInput(name, key) {
     when(core.getInput)
-        .calledWith(name)
+        .calledWith(name, expect.anything())
         .mockReturnValueOnce(key);
 }
 


### PR DESCRIPTION
#294 upgraded a major jest-when version, which makes `when` a little more strict about requiring all the arguments to be specified: https://github.com/timkindberg/jest-when/releases/tag/v3.0.0

I hadn't realised the tests are run against `pull_request_target` in the CI, so they only failed once merged to master. This PR fixes them up, but suffers from the same `pull_request_target` problem, so I've also added a `workflow_dispatch` trigger, and triggered the tests manually:

```bash
gh workflow run build.yml --ref fix-tests
✓ Created workflow_dispatch event for build.yml at fix-tests
```

Passing test results here: https://github.com/hashicorp/vault-action/actions/runs/2227014792