### PR TITLE
Add exportConfigEnv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Here are all the inputs available through `with`:
 | `kubernetesTokenPath`         | The path to the service-account secret with the jwt token for kubernetes based authentication                                                                                               |`/var/run/secrets/kubernetes.io/serviceaccount/token`         |          |
 | `authPayload`       | The JSON payload to be sent to Vault when using a custom authentication method.                                                                      |         |          |
 | `extraHeaders`      | A string of newline separated extra headers to include on every request.                                                                             |         |          |
+| `exportConfigEnv`   | Whether or not to export the `VAULT_ADDR`, `VAULT_NAMESPACE`, and `VAULT_SKIP_VERIFY` environment variables.                                         |         |          |
 | `exportEnv`         | Whether or not export secrets as environment variables.                                                                                              | `true`  |          |
 | `exportToken`       | Whether or not export Vault token as environment variables (i.e VAULT_TOKEN).                                                                        | `false` |          |
 | `caCertificate`     | Base64 encoded CA certificate the server certificate was signed with.                                                                                |         |          |

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
   extraHeaders:
     description: 'A string of newline separated extra headers to include on every request.'
     required: false
+  exportConfigEnv:
+    description: 'Whether to export `VAULT_ADDR`, `VAULT_NAMESPACE`, and `VAULT_SKIP_VERIFY` based on the configuration of the action'
+    default: false
+    required: false
   exportEnv:
     description: 'Whether or not export secrets as environment variables.'
     default: 'true'

--- a/integrationTests/enterprise/enterprise.test.js
+++ b/integrationTests/enterprise/enterprise.test.js
@@ -109,6 +109,23 @@ describe('integration', () => {
 
         expect(core.exportVariable).toBeCalledWith('OTHERSECRET', 'OTHERCUSTOMSECRET_IN_NAMESPACE');
     });
+
+    it('export Vault config env', async () => {
+        mockExportConfigEnv("true");
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledTimes(3);
+        expect(core.exportVariable).toBeCalledWith('VAULT_ADDR', vaultUrl);
+        expect(core.exportVariable).toBeCalledWith('VAULT_SKIP_VERIFY', 'false');
+        expect(core.exportVariable).toBeCalledWith('VAULT_NAMESPACE', vaultNamespace);
+    });
+
+    it('not export Vault config env', async () => {
+        mockExportConfigEnv("false");
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledTimes(0);
+    });
 });
 
 describe('authenticate with approle', () => {
@@ -288,4 +305,10 @@ function mockInput(secrets) {
     when(core.getInput)
         .calledWith('secrets', expect.anything())
         .mockReturnValueOnce(secrets);
+}
+
+function mockExportConfigEnv(doExport) {
+    when(core.getInput)
+        .calledWith('exportConfEnv', expect.anything())
+        .mockReturnValueOnce(doExport);
 }

--- a/src/action.js
+++ b/src/action.js
@@ -12,6 +12,7 @@ async function exportSecrets() {
     const vaultNamespace = core.getInput('namespace', { required: false });
     const extraHeaders = parseHeadersInput('extraHeaders', { required: false });
     const exportEnv = core.getInput('exportEnv', { required: false }) != 'false';
+    const exportConfigEnv = core.getInput('exportConfigEnv', { required: false }) != 'false';
     const exportToken = (core.getInput('exportToken', { required: false }) || 'false').toLowerCase() != 'false';
 
     const secretsInput = core.getInput('secrets', { required: false });
@@ -63,6 +64,14 @@ async function exportSecrets() {
 
     if (vaultNamespace != null) {
         defaultOptions.headers["X-Vault-Namespace"] = vaultNamespace;
+        if (exportConfigEnv) {
+            core.exportVariable('VAULT_NAMESPACE', `${vaultNamespace}`)
+        }
+    }
+
+    if (exportConfigEnv) {
+        core.exportVariable('VAULT_ADDR', `${vaultUrl}`)
+        core.exportVariable('VAULT_SKIP_VERIFY', `${tlsSkipVerify}`)
     }
 
     const vaultToken = await retrieveToken(vaultMethod, got.extend(defaultOptions));

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -295,6 +295,28 @@ describe('exportSecrets', () => {
         expect(core.setOutput).toBeCalledWith('key', '1');
     });
 
+    function mockExportConfigEnv(doExport) {
+        when(core.getInput)
+            .calledWith('exportConfEnv', expect.anything())
+            .mockReturnValueOnce(doExport);
+    }
+
+    it('export Vault config env', async () => {
+        mockExportConfigEnv("true");
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledTimes(2);
+        expect(core.exportVariable).toBeCalledWith('VAULT_ADDR', 'http://vault:8200');
+        expect(core.exportVariable).toBeCalledWith('VAULT_SKIP_VERIFY', 'false');
+    });
+
+    it('not export Vault config env', async () => {
+        mockExportConfigEnv("false");
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledTimes(0);
+    });
+
     it('single-line secret gets masked', async () => {
         mockInput('test key');
         mockVaultData({


### PR DESCRIPTION
This setting this will export `VAULT_ADDR`, `VAULT_SKIP_VERIFY`, and
`VAULT_NAMESPACE` when set in the action's configuration.
