### PR TITLE
use node16 for the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ inputs:
     required: false
     default: 3600
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'unlock'


### PR DESCRIPTION
Addresses #373 

## What

The PR sets `node16` as a runtime in the action.yaml file.

This version is already being used for [building and testing the action](https://github.com/hashicorp/vault-action/blob/main/.github/workflows/build.yml#L17) thus the change shouldn't have any side effects 

## Why

[GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
> We plan to migrate all actions to run on Node16 by Summer 2023. We will monitor the progress of the migration and listen to the community for how things are going before we define a final date.
To raise awareness of the upcoming change, we are adding a warning into workflows which contain Actions running on Node 12. This will come into effect starting on September 27th.

