### PR TITLE
fix: upgrade Node.js 12 to Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ inputs:
     required: false
     default: 3600
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'unlock'


### PR DESCRIPTION
As Node.js 12 actions are deprecated, we need to upgrade it to Node.js 16 For more information see:
  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/