### PR TITLE
fix(secrets): allow dynamic secrets to be read

### DIFF
--- a/src/secrets.js
+++ b/src/secrets.js
@@ -46,7 +46,7 @@ async function getSecrets(secretRequests, client) {
                 throw error
             }
         }
-        if (!selector.match(/.*[\.].*/)) {
+        if (!selector.match(/.*[\.\*].*/)) {
             selector = '"' + selector + '"'
         }
         selector = "data." + selector


### PR DESCRIPTION
This would allow reading of `data.*` thus accessing all dynamic secret properties.
Resolves #396 