### PR TITLE
Add Decoding to Secrets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,8 +76,8 @@ inputs:
     description: 'Time in seconds, after which token expires'
     required: false
     default: 3600
-  secretEncoding:
-    description: 'Encoding of the secret value. Can be "base64", "hex", "utf8".'
+  secretEncodingType:
+    description: 'The encoding type of the secret to decode. If not specified, the secret will not be decoded. Supported values: base64, hex, utf8'
     required: false
 runs:
   using: 'node16'

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,9 @@ inputs:
     description: 'Time in seconds, after which token expires'
     required: false
     default: 3600
+  secretEncoding:
+    description: 'Encoding of the secret value. Can be "base64", "hex", "utf8".'
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -17129,6 +17129,8 @@ async function exportSecrets() {
     const secretsInput = core.getInput('secrets', { required: false });
     const secretRequests = parseSecretsInput(secretsInput);
 
+    const secretEncoding = core.getInput('secretEncoding', { required: false });
+
     const vaultMethod = (core.getInput('method', { required: false }) || 'token').toLowerCase();
     const authPayload = core.getInput('authPayload', { required: false });
     if (!AUTH_METHODS.includes(vaultMethod) && !authPayload) {
@@ -17193,11 +17195,23 @@ async function exportSecrets() {
 
     const results = await getSecrets(requests, client);
 
+
     for (const result of results) {
-        const { value, request, cachedResponse } = result;
+        // Output the result
+
+        var value = result.value;
+        const request = result.request;
+        const cachedResponse = result.cachedResponse;
+
         if (cachedResponse) {
             core.debug('ℹ using cached response');
         }
+
+        // if a secret is encoded, decode it
+        if (secretEncoding) {
+            value = Buffer.from(value, secretEncoding).toString();
+        }
+
         for (const line of value.replace(/\r/g, '').split('\n')) {
             if (line.length > 0) {
                 command.issue('add-mask', line);
@@ -17211,7 +17225,7 @@ async function exportSecrets() {
     }
 };
 
-/** @typedef {Object} SecretRequest 
+/** @typedef {Object} SecretRequest
  * @property {string} path
  * @property {string} envVarName
  * @property {string} outputVarName

--- a/dist/index.js
+++ b/dist/index.js
@@ -17129,8 +17129,6 @@ async function exportSecrets() {
     const secretsInput = core.getInput('secrets', { required: false });
     const secretRequests = parseSecretsInput(secretsInput);
 
-    const secretEncoding = core.getInput('secretEncoding', { required: false });
-
     const vaultMethod = (core.getInput('method', { required: false }) || 'token').toLowerCase();
     const authPayload = core.getInput('authPayload', { required: false });
     if (!AUTH_METHODS.includes(vaultMethod) && !authPayload) {
@@ -17195,23 +17193,11 @@ async function exportSecrets() {
 
     const results = await getSecrets(requests, client);
 
-
     for (const result of results) {
-        // Output the result
-
-        var value = result.value;
-        const request = result.request;
-        const cachedResponse = result.cachedResponse;
-
+        const { value, request, cachedResponse } = result;
         if (cachedResponse) {
             core.debug('ℹ using cached response');
         }
-
-        // if a secret is encoded, decode it
-        if (secretEncoding) {
-            value = Buffer.from(value, secretEncoding).toString();
-        }
-
         for (const line of value.replace(/\r/g, '').split('\n')) {
             if (line.length > 0) {
                 command.issue('add-mask', line);
@@ -17225,7 +17211,7 @@ async function exportSecrets() {
     }
 };
 
-/** @typedef {Object} SecretRequest
+/** @typedef {Object} SecretRequest 
  * @property {string} path
  * @property {string} envVarName
  * @property {string} outputVarName

--- a/src/action.js
+++ b/src/action.js
@@ -6,6 +6,7 @@ const jsonata = require('jsonata');
 const { auth: { retrieveToken }, secrets: { getSecrets } } = require('./index');
 
 const AUTH_METHODS = ['approle', 'token', 'github', 'jwt', 'kubernetes'];
+const ENCODING_TYPES = ['base64', 'hex', 'utf8'];
 
 async function exportSecrets() {
     const vaultUrl = core.getInput('url', { required: true });
@@ -17,7 +18,7 @@ async function exportSecrets() {
     const secretsInput = core.getInput('secrets', { required: false });
     const secretRequests = parseSecretsInput(secretsInput);
 
-    const secretEncoding = core.getInput('secretEncoding', { required: false });
+    const secretEncodingType = core.getInput('secretEncodingType', { required: false });
 
     const vaultMethod = (core.getInput('method', { required: false }) || 'token').toLowerCase();
     const authPayload = core.getInput('authPayload', { required: false });
@@ -96,8 +97,8 @@ async function exportSecrets() {
         }
 
         // if a secret is encoded, decode it
-        if (secretEncoding) {
-            value = Buffer.from(value, secretEncoding).toString();
+        if (ENCODING_TYPES.includes(secretEncodingType)) {
+            value = Buffer.from(value, secretEncodingType).toString();
         }
 
         for (const line of value.replace(/\r/g, '').split('\n')) {

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -184,11 +184,30 @@ describe('exportSecrets', () => {
             .mockReturnValueOnce(doExport);
     }
 
+    function mockEncodeType(doEncode) {
+        when(core.getInput)
+            .calledWith('secretEncodingType', expect.anything())
+            .mockReturnValueOnce(doEncode);
+    }
+
     it('simple secret retrieval', async () => {
         mockInput('test key');
         mockVaultData({
             key: 1
         });
+
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledWith('KEY', '1');
+        expect(core.setOutput).toBeCalledWith('key', '1');
+    });
+
+    it('encoded secret retrieval', async () => {
+        mockInput('test key');
+        mockVaultData({
+            key: 'MQ=='
+        });
+        mockEncodeType('base64');
 
         await exportSecrets();
 


### PR DESCRIPTION
Adds support for encoded Vault secrets.
Example usage:
```
        with:
          namespace: ${{ secrets.VAULT_NAMESPACE }}
          url: ${{ secrets.VAULT_ADDR }}
          method: token
          token: ${{ secrets.VAULT_TOKEN }}
          tlsSkipVerify: false
          secretEncoding: "hex"
          secrets: |
            kv/test foohex | FOOHEX;
```

Resolves #105 