### PR TITLE
Handle undefined response in getSecrets error handler

### DIFF
--- a/src/secrets.js
+++ b/src/secrets.js
@@ -40,7 +40,7 @@ async function getSecrets(secretRequests, client) {
                 responseCache.set(requestPath, body);
             } catch (error) {
                 const {response} = error;
-                if (response.statusCode === 404) {
+                if (response?.statusCode === 404) {
                     throw Error(`Unable to retrieve result for "${path}" because it was not found: ${response.body.trim()}`)
                 }
                 throw error


### PR DESCRIPTION
Handle errors without a response property.  Testing against a vault with self signed certs w/out providing the `caCertificate` input.

Before:
![image](https://user-images.githubusercontent.com/1537768/221970491-114f579f-e657-4a9d-85ca-cb0101cbc76b.png)


After:
![image](https://user-images.githubusercontent.com/1537768/221970359-66249111-5f64-474d-8f3f-3f285588168e.png)

