### PR TITLE
Enhanced "Example Usage" section

### DIFF
--- a/integrationTests/e2e/setup.js
+++ b/integrationTests/e2e/setup.js
@@ -1,7 +1,7 @@
 const got = require('got');
 
 const vaultUrl = `${process.env.VAULT_HOST}:${process.env.VAULT_PORT}`;
-const vaultToken = `${process.env.VAULT_TOKEN || 'testtoken'}`
+const vaultToken = `${process.env.VAULT_TOKEN}` === undefined ? `${process.env.VAULT_TOKEN}` : "testtoken";
 
 (async () => {
     try {


### PR DESCRIPTION
+ added documentation on how to use the retrieved secrets
+ added an example of converting the vault-action outputs to json

Consuming vault-action output as a json file originally requested is this issue: #98 

After discussion it was proposed to not add this responsibility to the vault-action itself but document how it can be done using the GHA tools readily available.