### PR TITLE
Set output for the error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
 
 * Added support for userpass and ldap authentication methods [GH-440](https://github.com/hashicorp/vault-action/pull/440)
+* Define an output, `errorMessage`, for vault-action's error messages so subsequent steps can read the errors [GH-446](https://github.com/hashicorp/vault-action/pull/446)
 
 ## 2.5.0 (Jan 26th, 2023)
 
@@ -36,7 +37,7 @@ Bugs:
 * Errors due to replication delay for tokens will now be retried [GH-333](https://github.com/hashicorp/vault-action/pull/333)
 
 Improvements:
-* bump got from 11.5.1 to 11.8.5 [GH-344](https://github.com/hashicorp/vault-action/pull/344)  
+* bump got from 11.5.1 to 11.8.5 [GH-344](https://github.com/hashicorp/vault-action/pull/344)
 
 ## 2.4.1 (April 28th, 2022)
 
@@ -44,11 +45,11 @@ Improvements:
 * Make secrets parameter optional [GH-299](https://github.com/hashicorp/vault-action/pull/299)
 * auth/jwt: make "role" input optional [GH-291](https://github.com/hashicorp/vault-action/pull/291)
 * Write a better error message when secret not found [GH-306](https://github.com/hashicorp/vault-action/pull/306)
-* bump jest-when from 2.7.2 to 3.5.1 [GH-294](https://github.com/hashicorp/vault-action/pull/294)  
-* bump node-fetch from 2.6.1 to 2.6.7 [GH-308](https://github.com/hashicorp/vault-action/pull/308)  
-* bump @types/jest from 26.0.23 to 27.4.1 [GH-297](https://github.com/hashicorp/vault-action/pull/297)  
-* bump trim-off-newlines from 1.0.1 to 1.0.3 [GH-309](https://github.com/hashicorp/vault-action/pull/309)  
-* bump moment from 2.28.0 to 2.29.2 [GH-304](https://github.com/hashicorp/vault-action/pull/304)  
+* bump jest-when from 2.7.2 to 3.5.1 [GH-294](https://github.com/hashicorp/vault-action/pull/294)
+* bump node-fetch from 2.6.1 to 2.6.7 [GH-308](https://github.com/hashicorp/vault-action/pull/308)
+* bump @types/jest from 26.0.23 to 27.4.1 [GH-297](https://github.com/hashicorp/vault-action/pull/297)
+* bump trim-off-newlines from 1.0.1 to 1.0.3 [GH-309](https://github.com/hashicorp/vault-action/pull/309)
+* bump moment from 2.28.0 to 2.29.2 [GH-304](https://github.com/hashicorp/vault-action/pull/304)
 * bump @types/got from 9.6.11 to 9.6.12 [GH-266](https://github.com/hashicorp/vault-action/pull/266)
 
 ## 2.4.0 (October 21st, 2021)

--- a/src/entry.js
+++ b/src/entry.js
@@ -5,6 +5,7 @@ const { exportSecrets } = require('./action');
     try {
         await core.group('Get Vault Secrets', exportSecrets);
     } catch (error) {
+        core.setOutput("errorMessage", error.message);
         core.setFailed(error.message);
     }
 })();


### PR DESCRIPTION
In the event vault-action throws an error, the error message is sent to the workflow log when with `core.setFailed`, but that output is not accessible to other steps in the workflow.

This change sets an output for the error message, called errorMessage, than can be read by other steps within the workflow and parsed.