### PR TITLE
Document that the selector uses JSONata

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ attempt to `POST` to `auth/${method}/login` with the provided payload and parse 
 
 The `secrets` parameter is a set of multiple secret requests separated by the `;` character.
 
-Each secret request consists of the `path` and the `key` of the desired secret, and optionally the desired Env Var output name.
+Each secret request consists of the `path` and the `key` of the desired secret, and optionally the desired Env Var output name. 
+Note that the selector is using [JSONata](https://docs.jsonata.org/overview.html) and certain characters in keys may need to be escaped.
 
 ```raw
 {{ Secret Path }} {{ Secret Key or Selector }} | {{ Env/Output Variable Name }}


### PR DESCRIPTION
Documentation improvement to address #153 

The problem mentioned cannot be reproduced anymore, keys with dashes work as expected as was tested [when writing this comment](https://github.com/hashicorp/vault-action/issues/153#issuecomment-1452578840). An [acceptance test also covers this use case](https://github.com/hashicorp/vault-action/blob/main/integrationTests/basic/integration.test.js#L41) to prevent regressions.