### PR TITLE
Revert "chore(deps): bump jsrsasign from 10.6.1 to 10.8.6 (#451)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "got": "^11.8.5",
                 "jsonata": "^2.0.3",
-                "jsrsasign": "^10.8.6"
+                "jsrsasign": "^10.6.1"
             },
             "devDependencies": {
                 "@actions/core": "^1.10.0",
@@ -3128,9 +3128,9 @@
             }
         },
         "node_modules/jsrsasign": {
-            "version": "10.8.6",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
-            "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw==",
+            "version": "10.6.1",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
+            "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw==",
             "funding": {
                 "url": "https://github.com/kjur/jsrsasign#donations"
             }
@@ -6717,9 +6717,9 @@
             "integrity": "sha512-Up2H81MUtjqI/dWwWX7p4+bUMfMrQJVMN/jW6clFMTiYP528fBOBNtRu944QhKTs3+IsVWbgMeUTny5fw2VMUA=="
         },
         "jsrsasign": {
-            "version": "10.8.6",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.8.6.tgz",
-            "integrity": "sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw=="
+            "version": "10.6.1",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
+            "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw=="
         },
         "keyv": {
             "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "got": "^11.8.5",
         "jsonata": "^2.0.3",
-        "jsrsasign": "^10.8.6"
+        "jsrsasign": "^10.6.1"
     },
     "peerDependencies": {
         "@actions/core": ">=1 <2"


### PR DESCRIPTION
This reverts commit 14a4a058b4cbc3bcea5135eb4562147b0b143c88.

Trying to see if this will fix the e2e test failures: https://github.com/hashicorp/vault-action/actions/runs/5203835193/jobs/9387237718?pr=458