### PR TITLE
revert fix secrets stored in JSON format (#473)

### DIFF
--- a/integrationTests/e2e/e2e.test.js
+++ b/integrationTests/e2e/e2e.test.js
@@ -12,9 +12,6 @@ describe('e2e', () => {
         expect(process.env.SUBSEQUENT_TEST_SECRET).toBe("SUBSEQUENT_TEST_SECRET");
         expect(process.env.JSONSTRING).toBe('{"x":1,"y":"qux"}');
         expect(process.env.JSONSTRINGMULTILINE).toBe('{"x": 1, "y": "q\\nux"}');
-
-        let result = JSON.stringify('{"x":1,"y":"qux"}');
-        result = result.substring(1, result.length - 1);
-        expect(process.env.JSONDATA).toBe(result);
+        expect(process.env.JSONDATA).toBe('{"x":1,"y":"qux"}');
     });
 });

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -223,10 +223,7 @@ describe('exportSecrets', () => {
     it('JSON data secret retrieval', async () => {
         const jsonData = {"x":1,"y":2};
 
-        // for secrets stored in Vault as pure JSON, we call stringify twice
-        // and remove the surrounding quotes
-        let result = JSON.stringify(JSON.stringify(jsonData));
-        result = result.substring(1, result.length - 1);
+        let result = JSON.stringify(jsonData);
 
         mockInput('test key');
         mockVaultData({

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -82,18 +82,7 @@ async function selectData(data, selector) {
     }
 
     if (result.startsWith(`"`)) {
-        // Support multi-line secrets like JSON strings and ssh keys, see https://github.com/hashicorp/vault-action/pull/173
-        // Deserialize the value so that newlines and special characters are
-        // not escaped in our return value.
         result = JSON.parse(result);
-    } else {
-        // Support secrets stored in Vault as pure JSON, see https://github.com/hashicorp/vault-action/issues/194
-        // Serialize the value so that any special characters in the data are
-        // properly escaped.
-        result = JSON.stringify(result);
-        // strip the surrounding quotes added by stringify because the data did
-        // not have them in the first place
-        result = result.substring(1, result.length - 1);
     }
     return result;
 }


### PR DESCRIPTION
This change will revert to the behavior vault-action has exhibited [since v2.1.2](https://github.com/hashicorp/vault-action/commit/5e5c06a3c8e96b7c4757fe7a10e03469cdbd07bb#diff-3d2b59189eeedc2d428ddd632e97658fe310f587f7cb63b01f9b98ffc11c0197R10775). This ensure that all JSON is valid when set as an environment variable and that step output will be a JSON object. 

I can't find the source code of github actions to actually verify this, but it seems to me that when the step output is passed to another action using the `with` keyword, the github action framework actually `JSON.stringify`'s the data. This means that anything that accepts a Vault secret as input will have a valid JSON string that can then be `JSON.parse`'d. For example, this allows the following to work:

```
- name: Authenticate to Google Cloud
        uses: google-github-actions/auth@v1.1.1
        with:
          credentials_json: ${{ steps.vault_secrets.outputs.google_credentials }}
```

