### PR TITLE
Update to v2.7.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,21 +3,29 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG] "
 labels: bug
-assignees: RichiCoder1
 
 ---
 
-**Describe the bug**
+## Vault server version
+v0.0.0
+
+## vault-action version
+v0.0.0
+
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
 The yaml of the `vault-action` step, with any sensitive information masked or removed.
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Log Output**
-For the most verbose logs, [add a secret called `ACTIONS_STEP_DEBUG` with the value `true`](https://github.com/actions/toolkit/blob/main/docs/action-debugging.md). Then, re-run the workflow if possible and post the *raw logs* for the step here with any sensitive information masked or removed.
+## Log Output
+For the most verbose logs, add a secret called
+[`ACTIONS_STEP_DEBUG`](https://github.com/actions/toolkit/blob/main/docs/action-debugging.md)
+with the value `true`. Then, re-run the workflow if possible and post the *raw
+logs* for the step here with any sensitive information masked or removed.
 
-**Additional context**
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,18 +3,17 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[FEAT] "
 labels: enhancement
-assignees: RichiCoder1
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+### Description
+<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
+
+
+<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
+Relates OR Closes #0000
+
+
+### Checklist
+- [ ] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)
+- [ ] Did not commit changes to `dist/index.js` (This is only done for releases by vault-action maintainers)
+
+
+### Community Note
+
+* Please vote on this pull request by adding a 👍
+  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
+  to the original pull request comment to help the community and maintainers
+  prioritize this request
+* Please do not leave "+1" comments, they generate extra noise for pull request
+  followers and do not help prioritize the request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 * Add changes here
 
+## 2.7.4 (October 26, 2023)
+
+Features:
+
+* Add ability to specify a wildcard for the key name to get all keys in the path [GH-488](https://github.com/hashicorp/vault-action/pull/488)
+
 ## 2.7.3 (July 13, 2023)
 
 Bugs:


### PR DESCRIPTION
Prepare for v2.7.4 release.

Additionally, we update the
- PR template to include a checklist for
  - changelog entries and
  - a reminder to not commit to `dist/index.js` for non-release PRs
- Improvements to the bug and feature request templates