### PR TITLE
optionally revoke token at the end of workflow run

### DIFF
--- a/.github/workflows/local-test.yaml
+++ b/.github/workflows/local-test.yaml
@@ -59,3 +59,36 @@ jobs:
         echo
         cat secrets.json
         jq -c . < secrets.json
+  revoke-token:
+    name: revoke-token
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      with:
+        node-version: '16.14.0'
+
+    - name: NPM Install
+      run: npm ci
+
+    - name: NPM Build
+      run: npm run build
+
+    - name: Setup Vault
+      run: node ./integrationTests/e2e/setup.js
+      env:
+        VAULT_HOST: localhost
+        VAULT_PORT: 8200
+
+    - name: Import Secrets
+      id: import-secrets
+      # use the local changes
+      uses: ./
+      # run against a specific version of vault-action
+      # uses: hashicorp/vault-action@v2.1.2
+      with:
+        url: http://localhost:8200
+        method: token
+        token: testtoken
+        revokeToken: true

--- a/action.yml
+++ b/action.yml
@@ -89,10 +89,14 @@ inputs:
   secretEncodingType:
     description: 'The encoding type of the secret to decode. If not specified, the secret will not be decoded. Supported values: base64, hex, utf8'
     required: false
+  revokeKey:
+    description: 'When set to true, automatically revokes the vault token after the run is complete.'
+    default: "false"
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'
-  post: "dist/cache-save/index.js"
+  post: "dist/revoke/index.js"
 branding:
   icon: 'unlock'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,7 @@ inputs:
 runs:
   using: 'node16'
   main: 'dist/index.js'
+  post: "dist/cache-save/index.js"
 branding:
   icon: 'unlock'
   color: 'gray-dark'

--- a/dist/revoke/index.js
+++ b/dist/revoke/index.js
@@ -19344,11 +19344,11 @@ var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const core = __nccwpck_require__(2186);
-const { exportSecrets } = __nccwpck_require__(3348);
+const { revokeToken } = __nccwpck_require__(3348);
 
 (async () => {
     try {
-        await core.group('Get Vault Secrets', exportSecrets);
+        await revokeToken()
     } catch (error) {
         core.setOutput("errorMessage", error.message);
         core.setFailed(error.message);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,26 +8,26 @@ services:
     ports:
       - 8200:8200
     privileged: true
-  vault-enterprise:
-    image: hashicorp/vault-enterprise:latest
-    environment:
-      VAULT_DEV_ROOT_TOKEN_ID: testtoken
-      VAULT_LICENSE: ${VAULT_LICENSE_CI}
-    ports:
-      - 8200:8200
-    privileged: true
-  vault-tls:
-    image: hashicorp/vault:latest
-    hostname: vault-tls
-    environment:
-      VAULT_CAPATH: /etc/vault/ca.crt
-    ports:
-    - 8200:8200
-    privileged: true
-    volumes:
-    - ${PWD}/integrationTests/e2e-tls/configs:/etc/vault
-    - vault-data:/var/lib/vault:rw
-    entrypoint: vault server -config=/etc/vault/config.hcl
+  # vault-enterprise:
+  #   image: hashicorp/vault-enterprise:latest
+  #   environment:
+  #     VAULT_DEV_ROOT_TOKEN_ID: testtoken
+  #     VAULT_LICENSE: ${VAULT_LICENSE_CI}
+  #   ports:
+  #     - 8200:8200
+  #   privileged: true
+  # vault-tls:
+  #   image: hashicorp/vault:latest
+  #   hostname: vault-tls
+  #   environment:
+  #     VAULT_CAPATH: /etc/vault/ca.crt
+  #   ports:
+  #   - 8200:8200
+  #   privileged: true
+  #   volumes:
+  #   - ${PWD}/integrationTests/e2e-tls/configs:/etc/vault
+  #   - vault-data:/var/lib/vault:rw
+  #   entrypoint: vault server -config=/etc/vault/config.hcl
 
 volumes:
   vault-data:

--- a/integrationTests/basic/revoke.test.js
+++ b/integrationTests/basic/revoke.test.js
@@ -1,0 +1,118 @@
+jest.mock('@actions/core');
+jest.mock('@actions/core/lib/command');
+const core = require('@actions/core');
+
+const got = require('got');
+const { when } = require('jest-when');
+
+const { revokeToken, getDefaultOptions, VAULT_TOKEN_STATE } = require('../../src/action');
+const { retrieveToken } = require('../../src/auth');
+
+const vaultUrl = `http://${process.env.VAULT_HOST || 'localhost'}:${process.env.VAULT_PORT || '8200'}`;
+const vaultToken = `${process.env.VAULT_TOKEN || 'testtoken'}`
+
+describe('authenticate with userpass', () => {
+    const username = `testUsername`;
+    const password = `testPassword`;
+    beforeAll(async () => {
+        try {
+            // Verify Connection
+            await got(`${vaultUrl}/v1/secret/config`, {
+                headers: {
+                    'X-Vault-Token': vaultToken,
+                },
+            });
+
+            await got(`${vaultUrl}/v1/secret/data/userpass-test`, {
+                method: 'POST',
+                headers: {
+                    'X-Vault-Token': vaultToken,
+                },
+                json: {
+                    data: {
+                        secret: 'SUPERSECRET_WITH_USERPASS',
+                    },
+                },
+            });
+
+            // Enable userpass
+            try {
+                await got(`${vaultUrl}/v1/sys/auth/userpass`, {
+                    method: 'POST',
+                    headers: {
+                        'X-Vault-Token': vaultToken
+                    },
+                    json: {
+                        type: 'userpass'
+                    },
+                });
+            } catch (error) {
+                const { response } = error;
+                if (response.statusCode === 400 && response.body.includes("path is already in use")) {
+                    // Userpass might already be enabled from previous test runs
+                } else {
+                    throw error;
+                }
+            }
+
+            // Create policies
+            await got(`${vaultUrl}/v1/sys/policies/acl/userpass-test`, {
+                method: 'POST',
+                headers: {
+                    'X-Vault-Token': vaultToken
+                },
+                json: {
+                    "name": "userpass-test",
+                    "policy": `path \"auth/userpass/*\" {\n    capabilities = [\"read\", \"list\"]\n}\npath \"auth/userpass/users/${username}\"\n{\n    capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"]\n}\n\npath \"secret/data/*\" {\n    capabilities = [\"list\"]\n}\npath \"secret/metadata/*\" {\n    capabilities = [\"list\"]\n}\n\npath \"secret/data/userpass-test\" {\n    capabilities = [\"read\", \"list\"]\n}\npath \"secret/metadata/userpass-test\" {\n    capabilities = [\"read\", \"list\"]\n}\n`
+                },
+            });
+
+            // Create user
+            await got(`${vaultUrl}/v1/auth/userpass/users/${username}`, {
+                method: 'POST',
+                headers: {
+                    'X-Vault-Token': vaultToken
+                },
+                json: {
+                    password: `${password}`,
+                    policies: 'userpass-test'
+                },
+            });
+        } catch (err) {
+            console.warn('Create user in userpass', err.response.body);
+            throw err;
+        }
+    });
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        when(core.getInput)
+            .calledWith('method', expect.anything())
+            .mockReturnValueOnce('userpass');
+        when(core.getInput)
+            .calledWith('username', expect.anything())
+            .mockReturnValueOnce(username);
+        when(core.getInput)
+            .calledWith('password', expect.anything())
+            .mockReturnValueOnce(password);
+        // also queried by revokeToken
+        when(core.getInput)
+            .calledWith('url', expect.anything())
+            .mockReturnValue(`${vaultUrl}`);
+        when(core.getInput)
+            .calledWith('revokeToken', expect.anything())
+            .mockReturnValueOnce('true');
+    });
+
+    it('revoke token', async () => {
+        const defaultOptions = getDefaultOptions();
+        const vaultToken = await retrieveToken("userpass", got.extend(defaultOptions));
+        when(core.getState).calledWith(VAULT_TOKEN_STATE).mockReturnValue(vaultToken);
+        await revokeToken()
+        // token is now revoked so we can't revoke again
+        await expect(revokeToken())
+            .rejects
+            .toThrow('failed to revoke vault token. code: ERR_NON_2XX_3XX_RESPONSE, message: Response code 403 (Forbidden), vaultResponse: {"errors":["permission denied"]}');
+    })
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A Github Action that allows you to consume vault secrets as secure environment variables.",
     "main": "dist/index.js",
     "scripts": {
-        "build": "ncc build src/entry.js -o dist",
+        "build": "ncc build src/entry.js -o dist && ncc build src/revoke.js -o dist/revoke",
         "test": "jest",
         "test:integration:basic": "jest -c integrationTests/basic/jest.config.js",
         "test:integration:enterprise": "jest -c integrationTests/enterprise/jest.config.js",

--- a/src/revoke.js
+++ b/src/revoke.js
@@ -1,0 +1,11 @@
+const core = require('@actions/core');
+const { revokeToken } = require('./action');
+
+(async () => {
+    try {
+        await revokeToken()
+    } catch (error) {
+        core.setOutput("errorMessage", error.message);
+        core.setFailed(error.message);
+    }
+})();

--- a/src/revoke.test.js
+++ b/src/revoke.test.js
@@ -1,0 +1,38 @@
+jest.mock('got');
+jest.mock('@actions/core');
+
+const core = require('@actions/core');
+const got = require('got');
+const { when } = require('jest-when');
+
+const {
+    revokeClientToken
+} = require('./revoke');
+
+function mockApiResponse() {
+    const response = ""
+    got.post = jest.fn()
+    got.post.mockReturnValue(response)
+}
+function mockApiFailure() {
+    const response = { "errors": ["permission denied"] }
+    got.post = jest.fn()
+    got.post.mockReturnValue(response)
+}
+describe("test revoke for token", () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it("test revoke with success", async () => {
+        mockApiResponse()
+        await revokeClientToken(got)
+        console.log(got.post.mock.calls[0][1])
+    })
+
+    it("test revoke with error", async () => {
+        mockApiFailure()
+        await revokeClientToken(got)
+        console.log(got.post.mock.calls[0][1])
+    })
+})


### PR DESCRIPTION
### Description
adds the 'revokeToken' input to tell the action to automatically revoke the generated token after the run is complete.

closes #427 

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Did not commit changes to `dist/index.js` (This is only done for releases by vault-action maintainers)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
