### PR TITLE
feat: add new `ignoreNotFound` input to prevent the action from crashing when requested secrets do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
-* Add changes here
+Features:
+
+* Add `ignoreNotFound` input (default: false) to make the action ignore unexisting secrets without failing [GH-504](https://github.com/hashicorp/vault-action/pull/504)
 
 ## 2.7.4 (October 26, 2023)
 

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,10 @@ inputs:
   secretEncodingType:
     description: 'The encoding type of the secret to decode. If not specified, the secret will not be decoded. Supported values: base64, hex, utf8'
     required: false
+  ignoreNotFound:
+    description: 'Whether or not the action should exit successfully if some requested secrets were not found.'
+    default: 'false'
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3702,7 +3702,6 @@ function asPromise(normalizedOptions) {
                     request._beforeError(new types_1.HTTPError(response));
                     return;
                 }
-                request.destroy();
                 resolve(request.options.resolveBodyOnly ? response.body : response);
             });
             const onError = (error) => {
@@ -18936,7 +18935,6 @@ module.exports = {
 /***/ 8452:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const core = __nccwpck_require__(2186);
 const jsonata = __nccwpck_require__(4245);
 const { WILDCARD } = __nccwpck_require__(4438);
 const { normalizeOutputKey } = __nccwpck_require__(1608);
@@ -18961,7 +18959,6 @@ const { normalizeOutputKey } = __nccwpck_require__(1608);
   * @return {Promise<SecretResponse<TRequest>[]>}
   */
 async function getSecrets(secretRequests, client) {
-    const ignoreNotFound = (core.getInput('ignoreNotFound', { required: false }) || 'false').toLowerCase() != 'false';
     const responseCache = new Map();
     let results = [];
 
@@ -18982,13 +18979,7 @@ async function getSecrets(secretRequests, client) {
             } catch (error) {
                 const {response} = error;
                 if (response?.statusCode === 404) {
-                    msg = `Unable to retrieve result for "${path}" because it was not found: ${response.body.trim()}\n`;
-                    if (ignoreNotFound) {
-                        process.stdout.write(msg);
-                        continue;
-                    } else {
-                        throw Error(msg);
-                    }
+                    throw Error(`Unable to retrieve result for "${path}" because it was not found: ${response.body.trim()}`)
                 }
                 throw error
             }


### PR DESCRIPTION
### Description

Adding an optional input `ignoreNotFound` to make the action keep going even though one of the requested secret is not found (404).

We have a specific case where this is useful (necessary to be honest) and we thought it would be a nice improvement to your action codebase, since it is sometimes wanted to have a "always exit success" mecanism in GitHub Actions ecosystem.

Let me know what you think! Of course I can adapt my changes to whatever you prefer, like passing the new input variable from `action.js` to the `getSecrets` function instead of importing `core` in the `secrets.js` file (wasn't sure what was the best practice there).


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Did not commit changes to `dist/index.js` (This is only done for releases by vault-action maintainers)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
