### PR TITLE
Use nodejs 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Add changes here
+* update runtime to node20 for action
 
 ## 2.7.4 (October 26, 2023)
 

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ inputs:
     description: 'The encoding type of the secret to decode. If not specified, the secret will not be decoded. Supported values: base64, hex, utf8'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'unlock'


### PR DESCRIPTION
Node 16 has reached its end of life

More details here: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

### Checklist
- [X] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [X] Did not commit changes to `dist/index.js` (This is only done for releases by vault-action maintainers)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
