### PR TITLE
feature: add ignoreNotFound option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Features:
+
+* Add `ignoreNotFound` input (default: false) to prevent the action from failing when a secret does not exist [GH-518](https://github.com/hashicorp/vault-action/pull/518)
+
 ## 2.7.5 (January 30, 2024)
 
 Improvements:

--- a/README.md
+++ b/README.md
@@ -649,6 +649,13 @@ Base64 encoded client key the action uses to authenticate with Vault when mTLS i
 
 When set to true, disables verification of server certificates when testing the action.
 
+### `ignoreNotFound`
+
+**Type: `string`**\
+**Default: `false`**
+
+When set to true, prevents the action from failing when a secret does not exist.
+
 ## Masking - Hiding Secrets from Logs
 
 This action uses GitHub Action's built-in masking, so all variables will automatically be masked (aka hidden) if printed to the console or to logs.

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,10 @@ inputs:
   secretEncodingType:
     description: 'The encoding type of the secret to decode. If not specified, the secret will not be decoded. Supported values: base64, hex, utf8'
     required: false
+  ignoreNotFound:
+    description: 'Whether or not the action should exit successfully if some requested secrets were not found.'
+    required: false
+    default: 'false'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Add `ignoreNotFound` input (default: false) to prevent the action from failing when a secret does not exist

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Supercedes #506 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Did not commit changes to `dist/index.js` (This is only done for releases by vault-action maintainers)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
