### PR TITLE
approle: do not require secret_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Features:
+
+* `secretId` is no longer required for approle to support advanced use cases like machine login when `bind_secret_id` is false. [GH-522](https://github.com/hashicorp/vault-action/pull/522)
+
 ## 3.0.0 (February 15, 2024)
 
 Improvements:

--- a/src/auth.js
+++ b/src/auth.js
@@ -17,7 +17,7 @@ async function retrieveToken(method, client) {
     switch (method) {
         case 'approle': {
             const vaultRoleId = core.getInput('roleId', { required: true });
-            const vaultSecretId = core.getInput('secretId', { required: true });
+            const vaultSecretId = core.getInput('secretId', { required: false });
             return await getClientToken(client, method, path, { role_id: vaultRoleId, secret_id: vaultSecretId });
         }
         case 'github': {


### PR DESCRIPTION
### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
`secretId` is no longer required for approle to support advanced use cases like machine login when `bind_secret_id` is false.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #520 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Did not commit changes to `dist/index.js` (This is only done for releases by vault-action maintainers)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
