### PR TITLE
Prepare for v2.8.1 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '20.9.0'
+        node-version: '16.14.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -40,7 +40,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '20.9.0'
+        node-version: '16.14.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -76,7 +76,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '20.9.0'
+        node-version: '16.14.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -110,7 +110,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '20.9.0'
+        node-version: '16.14.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -207,7 +207,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '20.9.0'
+        node-version: '16.14.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/local-test.yaml
+++ b/.github/workflows/local-test.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '20.9.0'
+        node-version: '16.14.0'
 
     - name: NPM Install
       run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 2.8.1 (February 15, 2024)
+
+Bugs:
+
+* Revert [GH-509](https://github.com/hashicorp/vault-action/pull/509) which made a backwards incompatible bump of the node runtime from node16 to node20 [GH-524](https://github.com/hashicorp/vault-action/pull/524)
+
 ## 2.8.0 (February 1, 2024)
 
 Features:

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'unlock'


### PR DESCRIPTION
This reverts [GH-509](https://github.com/hashicorp/vault-action/pull/509) which made a backwards incompatible bump of the node runtime from node16 to node20 [GH-524](https://github.com/hashicorp/vault-action/pull/524). In particular, Github Enterprise does not support node20 at this time.

closes #526 

We plan to issue a v3 release with the node20 runtime.