### PR TITLE
Prepare for v3.0.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '16.14.0'
+        node-version: '20.9.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -40,7 +40,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '16.14.0'
+        node-version: '20.9.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -76,7 +76,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '16.14.0'
+        node-version: '20.9.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -110,7 +110,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '16.14.0'
+        node-version: '20.9.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -207,7 +207,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '16.14.0'
+        node-version: '20.9.0'
 
     - name: Setup NPM Cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/local-test.yaml
+++ b/.github/workflows/local-test.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
-        node-version: '16.14.0'
+        node-version: '20.9.0'
 
     - name: NPM Install
       run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 3.0.0 (February 15, 2024)
+
+Improvements:
+
+* Bump node runtime from node16 to node20 [GH-528](https://github.com/hashicorp/vault-action/pull/528)
+
 ## 2.8.1 (February 15, 2024)
 
 Bugs:

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'unlock'


### PR DESCRIPTION
Bump the node runtime from node16 to node20 which calls for a major version bump of the action from v2 to v3.

This is a follow up to https://github.com/hashicorp/vault-action/pull/527.