### PR TITLE
fix: remove case transformation in normalizeOutputKey

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14073,9 +14073,6 @@ function normalizeOutputKey(dataKey, isEnvVar = false) {
     .replace(".", "__")
     .replace(new RegExp("-", "g"), "")
     .replace(/[^\p{L}\p{N}_-]/gu, "");
-  if (isEnvVar) {
-    outputKey = outputKey.toUpperCase();
-  }
   return outputKey;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,9 +8,6 @@ function normalizeOutputKey(dataKey, isEnvVar = false) {
     .replace(".", "__")
     .replace(new RegExp("-", "g"), "")
     .replace(/[^\p{L}\p{N}_-]/gu, "");
-  if (isEnvVar) {
-    outputKey = outputKey.toUpperCase();
-  }
   return outputKey;
 }
 


### PR DESCRIPTION
### Description
Removes case transformation in normalizeOutputKey. Will allow keys to be exported as environment variables with case intact when using wildcard lookup. 

Closes #536

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)

### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
