### PR TITLE
fix wildcard handling when field contains dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Improvements:
+
+* fix wildcard handling when field contains dot [GH-542](https://github.com/hashicorp/vault-action/pull/542)
+
 Features:
 
 * `secretId` is no longer required for approle to support advanced use cases like machine login when `bind_secret_id` is false. [GH-522](https://github.com/hashicorp/vault-action/pull/522)

--- a/dist/index.js
+++ b/dist/index.js
@@ -18999,7 +18999,7 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
 
         body = JSON.parse(body);
 
-        if (selector == WILDCARD) {                     
+        if (selector == WILDCARD) {
             let keys = body.data;
             if (body.data["data"] != undefined) {
                 keys = keys.data;
@@ -19007,20 +19007,26 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
 
             for (let key in keys) {
                 let newRequest = Object.assign({},secretRequest);
-                newRequest.selector = key;                  
-                
+                newRequest.selector = key;
+
                 if (secretRequest.selector === secretRequest.outputVarName) {
                     newRequest.outputVarName = key;
-                    newRequest.envVarName = key;        		
-                }
-                else {
+                    newRequest.envVarName = key;
+                } else {
                     newRequest.outputVarName = secretRequest.outputVarName+key;
-                    newRequest.envVarName = secretRequest.envVarName+key;        		
+                    newRequest.envVarName = secretRequest.envVarName+key;
                 }
 
                 newRequest.outputVarName = normalizeOutputKey(newRequest.outputVarName);
-                newRequest.envVarName = normalizeOutputKey(newRequest.envVarName,true);   
+                newRequest.envVarName = normalizeOutputKey(newRequest.envVarName,true);
 
+                // JSONata field references containing reserved tokens should
+                // be enclosed in backticks
+                // https://docs.jsonata.org/simple#examples
+                if (key.includes(".")) {
+                    const backtick = '`';
+                    key = backtick.concat(key, backtick);
+                }
                 selector = key;
 
                 results = await selectAndAppendResults(
@@ -19034,13 +19040,13 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
         }
         else {
           results = await selectAndAppendResults(
-            selector, 
-            body, 
-            cachedResponse, 
-            secretRequest, 
+            selector,
+            body,
+            cachedResponse,
+            secretRequest,
             results
           );
-        }   
+        }
     }
 
     return results;

--- a/integrationTests/basic/integration.test.js
+++ b/integrationTests/basic/integration.test.js
@@ -31,6 +31,14 @@ describe('integration', () => {
             },
         });
 
+        await got(`${vaultUrl}/v1/secret/data/test-with-dot-char`, {
+            method: 'POST',
+            headers: {
+                'X-Vault-Token': vaultToken,
+            },
+            body: `{"data":{"secret.foo":"SUPERSECRET"}}`
+        });
+
         await got(`${vaultUrl}/v1/secret/data/nested/test`, {
             method: 'POST',
             headers: {
@@ -191,6 +199,16 @@ describe('integration', () => {
         expect(core.exportVariable).toBeCalledWith('SECRET', 'SUPERSECRET');
         expect(core.exportVariable).toBeCalledWith('NAMED_SECRET', 'SUPERSECRET');
         expect(core.exportVariable).toBeCalledWith('OTHERSECRETDASH', 'OTHERSUPERSECRET');
+    });
+
+    it('get wildcard secrets with dot char', async () => {
+        mockInput(`secret/data/test-with-dot-char * ;`);
+
+        await exportSecrets();
+
+        expect(core.exportVariable).toBeCalledTimes(1);
+
+        expect(core.exportVariable).toBeCalledWith('SECRET__FOO', 'SUPERSECRET');
     });
 
     it('get wildcard secrets', async () => {

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -59,7 +59,7 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
 
         body = JSON.parse(body);
 
-        if (selector == WILDCARD) {                     
+        if (selector == WILDCARD) {
             let keys = body.data;
             if (body.data["data"] != undefined) {
                 keys = keys.data;
@@ -67,20 +67,26 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
 
             for (let key in keys) {
                 let newRequest = Object.assign({},secretRequest);
-                newRequest.selector = key;                  
-                
+                newRequest.selector = key;
+
                 if (secretRequest.selector === secretRequest.outputVarName) {
                     newRequest.outputVarName = key;
-                    newRequest.envVarName = key;        		
-                }
-                else {
+                    newRequest.envVarName = key;
+                } else {
                     newRequest.outputVarName = secretRequest.outputVarName+key;
-                    newRequest.envVarName = secretRequest.envVarName+key;        		
+                    newRequest.envVarName = secretRequest.envVarName+key;
                 }
 
                 newRequest.outputVarName = normalizeOutputKey(newRequest.outputVarName);
-                newRequest.envVarName = normalizeOutputKey(newRequest.envVarName,true);   
+                newRequest.envVarName = normalizeOutputKey(newRequest.envVarName,true);
 
+                // JSONata field references containing reserved tokens should
+                // be enclosed in backticks
+                // https://docs.jsonata.org/simple#examples
+                if (key.includes(".")) {
+                    const backtick = '`';
+                    key = backtick.concat(key, backtick);
+                }
                 selector = key;
 
                 results = await selectAndAppendResults(
@@ -94,13 +100,13 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
         }
         else {
           results = await selectAndAppendResults(
-            selector, 
-            body, 
-            cachedResponse, 
-            secretRequest, 
+            selector,
+            body,
+            cachedResponse,
+            secretRequest,
             results
           );
-        }   
+        }
     }
 
     return results;


### PR DESCRIPTION
### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #541 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)


