### PR TITLE
feat: added double asterisk wildcard selector to prevent uppercasing of keys before exporting envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 Features:
 
 * `secretId` is no longer required for approle to support advanced use cases like machine login when `bind_secret_id` is false. [GH-522](https://github.com/hashicorp/vault-action/pull/522)
+* Wildcard secret imports can use `**` to retain case of exported env keys [GH-545](https://github.com/hashicorp/vault-action/pull/545)
 
 ## 3.0.0 (February 15, 2024)
 

--- a/README.md
+++ b/README.md
@@ -407,8 +407,6 @@ with:
         secret/data/ci/aws ** | MYAPP_ ;
 ```
 
-```yaml
-
 ## Other Secret Engines
 
 Vault Action currently supports retrieving secrets from any engine where secrets

--- a/README.md
+++ b/README.md
@@ -399,6 +399,16 @@ with:
         secret/data/ci/aws * | MYAPP_ ;
 ```
 
+When using the `exportEnv` option all exported keys will be normalized to uppercase.  For example, the key `SecretKey` would be exported as `MYAPP_SECRETKEY`. You disable uppercase normalization by specifying double asterisks `**` in the selector path:
+
+```yaml
+with:
+    secrets: |
+        secret/data/ci/aws ** | MYAPP_ ;
+```
+
+```yaml
+
 ## Other Secret Engines
 
 Vault Action currently supports retrieving secrets from any engine where secrets

--- a/integrationTests/basic/integration.test.js
+++ b/integrationTests/basic/integration.test.js
@@ -313,7 +313,7 @@ describe('integration', () => {
             expect(core.exportVariable).toBeCalledWith('FOO', 'bar');
         });
 
-        it('wildcard supports cubbyhole', async () => {            
+        it('wildcard supports cubbyhole with uppercase transform', async () => {
             mockInput('/cubbyhole/test *');
 
             await exportSecrets();
@@ -322,6 +322,32 @@ describe('integration', () => {
 
             expect(core.exportVariable).toBeCalledWith('FOO', 'bar');
             expect(core.exportVariable).toBeCalledWith('ZIP', 'zap');
+        });
+
+        it('wildcard supports cubbyhole with no change in case', async () => {
+            mockInput('/cubbyhole/test **');
+
+            await exportSecrets();
+
+            expect(core.exportVariable).toBeCalledTimes(2);
+
+            expect(core.exportVariable).toBeCalledWith('foo', 'bar');
+            expect(core.exportVariable).toBeCalledWith('zip', 'zap');
+        });
+
+        it('wildcard supports cubbyhole with mixed case change', async () => {
+            mockInput(`
+            /cubbyhole/test * ;
+            /cubbyhole/test **`);
+
+            await exportSecrets();
+
+            expect(core.exportVariable).toBeCalledTimes(4);
+
+            expect(core.exportVariable).toBeCalledWith('FOO', 'bar');
+            expect(core.exportVariable).toBeCalledWith('ZIP', 'zap');
+            expect(core.exportVariable).toBeCalledWith('foo', 'bar');
+            expect(core.exportVariable).toBeCalledWith('zip', 'zap');
         });
         
         it('caches responses', async () => {            

--- a/src/action.js
+++ b/src/action.js
@@ -4,7 +4,7 @@ const command = require('@actions/core/lib/command');
 const got = require('got').default;
 const jsonata = require('jsonata');
 const { normalizeOutputKey } = require('./utils');
-const { WILDCARD } = require('./constants');
+const { WILDCARD, WILDCARD_UPPERCASE } = require('./constants');
 
 const { auth: { retrieveToken }, secrets: { getSecrets } } = require('./index');
 
@@ -174,7 +174,7 @@ function parseSecretsInput(secretsInput) {
         const selectorAst = jsonata(selectorQuoted).ast();
         const selector = selectorQuoted.replace(new RegExp('"', 'g'), '');
 
-        if (selector !== WILDCARD && (selectorAst.type !== "path" || selectorAst.steps[0].stages) && selectorAst.type !== "string" && !outputVarName) {
+        if (selector !== WILDCARD && selector !== WILDCARD_UPPERCASE && (selectorAst.type !== "path" || selectorAst.steps[0].stages) && selectorAst.type !== "string" && !outputVarName) {
             throw Error(`You must provide a name for the output key when using json selectors. Input: "${secret}"`);
         }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,7 @@
-const WILDCARD = '*';
+const WILDCARD_UPPERCASE = '*';
+const WILDCARD = '**';
 
 module.exports = {
-    WILDCARD
+    WILDCARD,
+    WILDCARD_UPPERCASE,
 };

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -1,5 +1,5 @@
 const jsonata = require("jsonata");
-const { WILDCARD } = require("./constants");
+const { WILDCARD, WILDCARD_UPPERCASE} = require("./constants");
 const { normalizeOutputKey } = require("./utils");
 const core = require('@actions/core');
 
@@ -26,6 +26,7 @@ const core = require('@actions/core');
 async function getSecrets(secretRequests, client, ignoreNotFound) {
     const responseCache = new Map();
     let results = [];
+    let upperCaseEnv = false;
 
     for (const secretRequest of secretRequests) {
         let { path, selector } = secretRequest;
@@ -59,7 +60,8 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
 
         body = JSON.parse(body);
 
-        if (selector == WILDCARD) {
+        if (selector === WILDCARD || selector === WILDCARD_UPPERCASE) {
+            upperCaseEnv = selector === WILDCARD_UPPERCASE;
             let keys = body.data;
             if (body.data["data"] != undefined) {
                 keys = keys.data;
@@ -78,7 +80,7 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
                 }
 
                 newRequest.outputVarName = normalizeOutputKey(newRequest.outputVarName);
-                newRequest.envVarName = normalizeOutputKey(newRequest.envVarName,true);
+                newRequest.envVarName = normalizeOutputKey(newRequest.envVarName, upperCaseEnv);
 
                 // JSONata field references containing reserved tokens should
                 // be enclosed in backticks

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,12 +3,12 @@
  * @param {string} dataKey
  * @param {boolean=} isEnvVar
  */
-function normalizeOutputKey(dataKey, isEnvVar = false) {
+function normalizeOutputKey(dataKey, upperCase = false) {
   let outputKey = dataKey
     .replace(".", "__")
     .replace(new RegExp("-", "g"), "")
     .replace(/[^\p{L}\p{N}_-]/gu, "");
-  if (isEnvVar) {
+  if (upperCase) {
     outputKey = outputKey.toUpperCase();
   }
   return outputKey;


### PR DESCRIPTION


### Description
When using the wildcard to match multiple secrets to export as env variables, all keys get uppercased. There are situations where this is undesirable. To maintain backwards compatibility I've added an alterative double asterisk `**` which will avoid uppercasing exported env keys.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/vault-action/pull/537

Closes https://github.com/hashicorp/vault-action/issues/536


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
