### PR TITLE
docs: add namespace example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,6 @@ steps:
       uses: hashicorp/vault-action
       with:
         url: https://vault-enterprise.mycompany.com:8200
-        caCertificate: ${{ secrets.VAULT_CA_CERT }}
         method: token
         token: ${{ secrets.VAULT_TOKEN }}
         namespace: admin
@@ -494,6 +493,25 @@ steps:
             secret/data/ci/aws accessKey | AWS_ACCESS_KEY_ID ;
             secret/data/ci/aws secretKey | AWS_SECRET_ACCESS_KEY ;
             secret/data/ci npm_token
+```
+
+Alternatively, you may need to authenticate to the root namespace and retrieve
+a secret from a different namespace. To do this, do not set the `namespace`
+parameter. Instead set the namespace in the secret path. For example, `<NAMESPACE>/secret/data/app`:
+
+```yaml
+steps:
+    # ...
+    - name: Import Secrets
+      uses: hashicorp/vault-action
+      with:
+        url: https://vault-enterprise.mycompany.com:8200
+        method: token
+        token: ${{ secrets.VAULT_TOKEN }}
+        secrets: |
+            namespace-1/secret/data/ci/aws accessKey | AWS_ACCESS_KEY_ID ;
+            namespace-1/secret/data/ci/aws secretKey | AWS_SECRET_ACCESS_KEY ;
+            namespace-1/secret/data/ci npm_token
 ```
 
 ## Reference

--- a/integrationTests/basic/jwt_auth.test.js
+++ b/integrationTests/basic/jwt_auth.test.js
@@ -97,6 +97,8 @@ describe('jwt auth', () => {
             }
         });
 
+        // write the jwt config, the jwt role will be written on a per-test
+        // basis since the audience may vary
         await got(`${vaultUrl}/v1/auth/jwt/config`, {
             method: 'POST',
             headers: {
@@ -105,22 +107,6 @@ describe('jwt auth', () => {
             json: {
                 jwt_validation_pubkeys: publicRsaKey,
                 default_role: "default"
-            }
-        });
-
-        await got(`${vaultUrl}/v1/auth/jwt/role/default`, {
-            method: 'POST',
-            headers: {
-                'X-Vault-Token': vaultToken,
-            },
-            json: {
-                role_type: 'jwt',
-                bound_audiences: null,
-                bound_claims: {
-                    iss: 'vault-action'
-                },
-                user_claim: 'iss',
-                policies: ['reader']
             }
         });
 
@@ -138,6 +124,24 @@ describe('jwt auth', () => {
     });
 
     describe('authenticate with private key', () => {
+        beforeAll(async () => {
+            await got(`${vaultUrl}/v1/auth/jwt/role/default`, {
+                method: 'POST',
+                headers: {
+                    'X-Vault-Token': vaultToken,
+                },
+                json: {
+                    role_type: 'jwt',
+                    bound_audiences: null,
+                    bound_claims: {
+                        iss: 'vault-action'
+                    },
+                    user_claim: 'iss',
+                    policies: ['reader']
+                }
+            });
+        });
+
         beforeEach(() => {
             jest.resetAllMocks();
 
@@ -170,6 +174,22 @@ describe('jwt auth', () => {
 
     describe('authenticate with Github OIDC', () => {
         beforeAll(async () => {
+            await got(`${vaultUrl}/v1/auth/jwt/role/default`, {
+                method: 'POST',
+                headers: {
+                    'X-Vault-Token': vaultToken,
+                },
+                json: {
+                    role_type: 'jwt',
+                    bound_audiences: 'https://github.com/hashicorp/vault-action',
+                    bound_claims: {
+                        iss: 'vault-action'
+                    },
+                    user_claim: 'iss',
+                    policies: ['reader']
+                }
+            });
+
             await got(`${vaultUrl}/v1/auth/jwt/role/default-sigstore`, {
                 method: 'POST',
                 headers: {
@@ -177,7 +197,7 @@ describe('jwt auth', () => {
                 },
                 json: {
                     role_type: 'jwt',
-                    bound_audiences: null,
+                    bound_audiences: 'sigstore',
                     bound_claims: {
                         iss: 'vault-action',
                         aud: 'sigstore',


### PR DESCRIPTION
Closes https://github.com/hashicorp/vault-action/issues/559

the tests were failing due to the jwt auth's recent behavior change in 1.17 so that is fixed here as well. See https://developer.hashicorp.com/vault/docs/upgrading/upgrade-to-1.17.x#jwt-auth-login-requires-bound-audiences-on-the-role