### PR TITLE
feat: Add PKI capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 Features:
 
 * `secretId` is no longer required for approle to support advanced use cases like machine login when `bind_secret_id` is false. [GH-522](https://github.com/hashicorp/vault-action/pull/522)
+* Use `pki` configuration to generate certificates from Vault [GH-564](https://github.com/hashicorp/vault-action/pull/564)
 
 ## 3.0.0 (February 15, 2024)
 

--- a/README.md
+++ b/README.md
@@ -417,12 +417,34 @@ secret/data/test
 
 Note that the full path is not `secret/test`, but `secret/data/test`.
 
+## PKI Certificate Requests
+
+You can use the `pki` option to generate a certificate and private key for a given role.
+
+````yaml
+with:
+    pki: |
+        pki/issue/rolename {"common_name": "role.mydomain.com", "ttl": "1h"} ;
+        pki/issue/otherrole {"common_name": "otherrole.mydomain.com", "ttl": "1h"} ;
+```
+
+Resulting in:
+
+```bash
+ROLENAME_CA=-----BEGIN CERTIFICATE-----...
+ROLENAME_CERT=-----BEGIN CERTIFICATE-----...
+ROLENAME_KEY=-----BEGIN RSA PRIVATE KEY-----...
+ROLENAME_CA_CHAIN=-----BEGIN CERTIFICATE-----...
+OTHERROLE_CA=-----BEGIN CERTIFICATE-----...
+OTHERROLE_CERT=-----BEGIN CERTIFICATE-----...
+OTHERROLE_KEY=-----BEGIN RSA PRIVATE KEY-----...
+OTHERROLE_CA_CHAIN=-----BEGIN CERTIFICATE-----...
+````
+
 ## Other Secret Engines
 
 Vault Action currently supports retrieving secrets from any engine where secrets
-are retrieved via `GET` requests.  This means secret engines such as PKI are currently
-not supported due to their requirement of sending parameters along with the request
-(such as `common_name`).
+are retrieved via `GET` requests, except for the PKI engine as noted above.
 
 For example, to request a secret from the `cubbyhole` secret engine:
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   secrets:
     description: 'A semicolon-separated list of secrets to retrieve. These will automatically be converted to environmental variable keys. See README for more details'
     required: false
+  pki:
+    description: 'A semicolon-separated list of certificates to generate. These will automatically be converted to environment variable keys. Cannot be used with "secrets". See README for more details'
+    required: false
   namespace:
     description: 'The Vault namespace from which to query secrets. Vault Enterprise only, unset by default'
     required: false

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 const auth = require('./auth');
 const secrets = require('./secrets');
+const pki = require('./pki');
 
 module.exports = {
     auth,
-    secrets
+    secrets,
+    pki
 };

--- a/src/pki.js
+++ b/src/pki.js
@@ -1,0 +1,76 @@
+const { normalizeOutputKey } = require('./utils');
+const core = require('@actions/core');
+
+/** A map of postfix values mapped to the key in the certificate response and a transformer function */
+const outputMap = {
+    cert: { key: 'certificate', tx: (v) => v },
+    key: { key: 'private_key', tx: (v) => v },
+    ca: { key: 'issuing_ca', tx: (v) => v },
+    ca_chain: { key: 'ca_chain', tx: (v) => v.join('\n') },
+};
+
+/**
+ * @typedef PkiRequest
+ * @type {object}
+ * @property {string} path - The path to the PKI endpoint
+ * @property {Record<string, any>} parameters - The parameters to send to the PKI endpoint
+ * @property {string} envVarName - The name of the environment variable to set
+ * @property {string} outputVarName - The name of the output variable to set
+ */
+
+/**
+ * @typedef {Object} PkiResponse
+ * @property {PkiRequest} request
+ * @property {string} value
+ * @property {boolean} cachedResponse
+ */
+
+/**
+ * Generate and return the certificates from the PKI engine
+ * @param {Array<PkiRequest>} pkiRequests
+ * @param {import('got').Got} client
+ * @return {Promise<Array<PkiResponse>>}
+ */
+async function getCertificates(pkiRequests, client) {
+    /** @type Array<PkiResponse> */
+    let results = [];
+
+    for (const pkiRequest of pkiRequests) {
+        const { path, parameters } = pkiRequest;
+
+        const requestPath = `v1/${path}`;
+        let body;
+        try {
+            const result = await client.post(requestPath, {
+                body: JSON.stringify(parameters),
+            });
+            body = result.body;
+        } catch (error) {
+            core.error(`✘ ${error.response?.body ?? error.message}`);
+            throw error;
+        }
+
+        body = JSON.parse(body);
+
+        core.info(`✔ Successfully generated certificate (serial number ${body.data.serial_number})`);
+
+        Object.entries(outputMap).forEach(([key, value]) => {
+            const val = value.tx(body.data[value.key]);
+            results.push({
+                request: {
+                    ...pkiRequest,
+                    envVarName: normalizeOutputKey(`${pkiRequest.envVarName}_${key}`, true),
+                    outputVarName: normalizeOutputKey(`${pkiRequest.outputVarName}_${key}`),
+                },
+                value: val,
+                cachedResponse: false,
+            });
+        });
+    }
+
+    return results;
+}
+
+module.exports = {
+    getCertificates,
+};


### PR DESCRIPTION
### Description
Add the ability to generate PKI certificates from Vault's PKI engine. You can now use the `pki` option to generate a certificate and private key for a given role.

````yaml
with:
    pki: |
        pki/issue/rolename {"common_name": "role.mydomain.com", "ttl": "1h"} ;
        pki/issue/otherrole {"common_name": "otherrole.mydomain.com", "ttl": "1h"} ;
```

Resulting in:

```bash
ROLENAME_CA=-----BEGIN CERTIFICATE-----...
ROLENAME_CERT=-----BEGIN CERTIFICATE-----...
ROLENAME_KEY=-----BEGIN RSA PRIVATE KEY-----...
ROLENAME_CA_CHAIN=-----BEGIN CERTIFICATE-----...
OTHERROLE_CA=-----BEGIN CERTIFICATE-----...
OTHERROLE_CERT=-----BEGIN CERTIFICATE-----...
OTHERROLE_KEY=-----BEGIN RSA PRIVATE KEY-----...
OTHERROLE_CA_CHAIN=-----BEGIN CERTIFICATE-----...
````

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
