### PR TITLE
Retry core.getIDToken for JWT Auth Method

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -35,7 +35,10 @@ async function retrieveToken(method, client) {
             const githubAudience = core.getInput('jwtGithubAudience', { required: false });
 
             if (!privateKey) {
-                jwt = await core.getIDToken(githubAudience)
+                jwt = await retryAsyncFunction( 3, 3000, core.getIDToken, githubAudience)
+                  .then((result) => {
+                    return result;
+                });
             } else {
                 jwt = generateJwt(privateKey, keyPassword, Number(tokenTtl));
             }
@@ -140,6 +143,30 @@ async function getClientToken(client, method, path, payload) {
     } else {
         throw Error(`Unable to retrieve token from ${method}'s login endpoint.`);
     }
+}
+
+/***
+ * Generic function for retrying an async function
+ * @param {number} retries
+ * @param {number} delay milliseconds
+ * @param {Function} func
+ * @param {any[]} args
+ */
+async function retryAsyncFunction(retries, delay, func, ...args) {
+  let attempt = 0;
+  while (attempt < retries) {
+    try {
+      const result = await func(...args);
+      return result;
+    } catch (error) {
+      attempt++;
+      if (attempt < retries) {
+        await new Promise(resolve => setTimeout(resolve, delay));
+      } else {
+        throw error;
+      }
+    }
+  }
 }
 
 /***

--- a/src/auth.test.js
+++ b/src/auth.test.js
@@ -85,4 +85,24 @@ describe("test retrival for token", () => {
         const url = got.post.mock.calls[0][0]
         expect(url).toContain('differentK8sPath')
     })
+
+    it("test retrieval with jwt", async () => {
+        const method = "jwt"
+        const jwtToken = "someTestToken"
+        const testRole = "testRole"
+        const privateKeyRaw = ""
+
+        mockApiResponse()
+        mockInput("role", testRole)
+        mockInput("jwtPrivateKey", privateKeyRaw)
+        core.getIDToken = jest.fn()
+        core.getIDToken.mockReturnValueOnce(jwtToken)
+        const token = await retrieveToken(method, got)
+        expect(token).toEqual(testToken)
+        const payload = got.post.mock.calls[0][1].json
+        expect(payload).toEqual({ jwt: jwtToken,  role: testRole })
+        const url = got.post.mock.calls[0][0]
+        expect(url).toContain('jwt')
+  })
+
 })


### PR DESCRIPTION
### Description
core.getIDToken intermittently fails for both cloud hosted and on prem runners. This causes issues with nightly builds failing.

Adds a generic async retry function. Adds 3 retries with 3 seconds of delay between core.getIDToken calls.

Closes #525 
