### PR TITLE
Prevent possible DoS via polynomial regex

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19271,7 +19271,7 @@ const selectAndAppendResults = async (
   secretRequest,
   results
 ) => {
-  if (!selector.match(/.*[\.].*/)) {
+  if (!selector.includes(".")) {
     selector = '"' + selector + '"';
   }
   selector = "data." + selector;

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -153,7 +153,7 @@ const selectAndAppendResults = async (
   secretRequest,
   results
 ) => {
-  if (!selector.match(/.*[\.].*/)) {
+  if (!selector.includes(".")) {
     selector = '"' + selector + '"';
   }
   selector = "data." + selector;


### PR DESCRIPTION
### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
A regular expression that can require polynomial time to match may be vulnerable to denial-of-service attacks. To prevent this, we use the builtin [String.prototype.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes).

