### PR TITLE
Proxy support through global agent bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ is not meant to modify Vault’s state.
     - [KV secrets engine version 2](#kv-secrets-engine-version-2)
   - [Other Secret Engines](#other-secret-engines)
   - [Adding Extra Headers](#adding-extra-headers)
+  - [Proxy Support](#proxy-support)
   - [HashiCorp Cloud Platform or Vault Enterprise](#hashicorp-cloud-platform-or-vault-enterprise)
     - [Namespace](#namespace)
   - [Reference](#reference)
@@ -501,6 +502,36 @@ with:
 ```
 
 This will automatically add the `x-secure-id` and `x-secure-secret` headers to every request to Vault.
+
+## Proxy Support
+
+If your action runs on a self-hosted GitHub Runner behind a proxy, you can enable proxy support through [global-agent environment variables](https://github.com/gajus/global-agent?tab=readme-ov-file#environment-variables),
+which supports the `got` request library (https://github.com/gajus/global-agent?tab=readme-ov-file#supported-libraries)
+
+```yaml
+steps:
+  # ...
+  - name: Import Secrets
+    uses: hashicorp/vault-action
+    with:
+      url: https://vault-enterprise.mycompany.com:8200
+      method: token
+      token: ${{ secrets.VAULT_TOKEN }}
+      namespace: admin
+      secrets: |
+        secret/data/ci/aws accessKey | AWS_ACCESS_KEY_ID ;
+        secret/data/ci/aws secretKey | AWS_SECRET_ACCESS_KEY ;
+        secret/data/ci npm_token
+    env:
+      GLOBAL_AGENT_HTTP_PROXY: "http://replace-with-your-proxy-host-and-port"
+```
+
+- The `GLOBAL_AGENT_HTTP_PROXY` environment variable will manage HTTP and HTTPS requests.
+- The URL protocol must be "http:", otherwise an `UNEXPECTED_STATE_ERROR` will be thrown; empty/undefined values will be gracefully ignored.
+- With the `GLOBAL_AGENT_HTTPS_PROXY` environment variable it is possible to set a distinct proxy for HTTPS requests.
+- Proxy support will be only available for Node.js v10 and above.
+
+For further information, see [global-agent library](https://github.com/gajus/global-agent?tab=readme-ov-file#global-agent)
 
 ## HashiCorp Cloud Platform or Vault Enterprise
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2305,6 +2305,72 @@ module.exports["default"] = timer;
 
 /***/ }),
 
+/***/ 8641:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.boolean = void 0;
+const boolean = function (value) {
+    switch (Object.prototype.toString.call(value)) {
+        case '[object String]':
+            return ['true', 't', 'yes', 'y', 'on', '1'].includes(value.trim().toLowerCase());
+        case '[object Number]':
+            return value.valueOf() === 1;
+        case '[object Boolean]':
+            return value.valueOf();
+        default:
+            return false;
+    }
+};
+exports.boolean = boolean;
+
+
+/***/ }),
+
+/***/ 1253:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.isBooleanable = exports.boolean = void 0;
+const boolean_1 = __nccwpck_require__(8641);
+Object.defineProperty(exports, "boolean", ({ enumerable: true, get: function () { return boolean_1.boolean; } }));
+const isBooleanable_1 = __nccwpck_require__(4030);
+Object.defineProperty(exports, "isBooleanable", ({ enumerable: true, get: function () { return isBooleanable_1.isBooleanable; } }));
+
+
+/***/ }),
+
+/***/ 4030:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.isBooleanable = void 0;
+const isBooleanable = function (value) {
+    switch (Object.prototype.toString.call(value)) {
+        case '[object String]':
+            return [
+                'true', 't', 'yes', 'y', 'on', '1',
+                'false', 'f', 'no', 'n', 'off', '0'
+            ].includes(value.trim().toLowerCase());
+        case '[object Number]':
+            return [0, 1].includes(value.valueOf());
+        case '[object Boolean]':
+            return true;
+        default:
+            return false;
+    }
+};
+exports.isBooleanable = isBooleanable;
+
+
+/***/ }),
+
 /***/ 2286:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -3446,6 +3512,134 @@ module.exports["default"] = deferToConnect;
 
 /***/ }),
 
+/***/ 5653:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var $defineProperty = __nccwpck_require__(6123);
+
+var $SyntaxError = __nccwpck_require__(5474);
+var $TypeError = __nccwpck_require__(6361);
+
+var gopd = __nccwpck_require__(8501);
+
+/** @type {import('.')} */
+module.exports = function defineDataProperty(
+	obj,
+	property,
+	value
+) {
+	if (!obj || (typeof obj !== 'object' && typeof obj !== 'function')) {
+		throw new $TypeError('`obj` must be an object or a function`');
+	}
+	if (typeof property !== 'string' && typeof property !== 'symbol') {
+		throw new $TypeError('`property` must be a string or a symbol`');
+	}
+	if (arguments.length > 3 && typeof arguments[3] !== 'boolean' && arguments[3] !== null) {
+		throw new $TypeError('`nonEnumerable`, if provided, must be a boolean or null');
+	}
+	if (arguments.length > 4 && typeof arguments[4] !== 'boolean' && arguments[4] !== null) {
+		throw new $TypeError('`nonWritable`, if provided, must be a boolean or null');
+	}
+	if (arguments.length > 5 && typeof arguments[5] !== 'boolean' && arguments[5] !== null) {
+		throw new $TypeError('`nonConfigurable`, if provided, must be a boolean or null');
+	}
+	if (arguments.length > 6 && typeof arguments[6] !== 'boolean') {
+		throw new $TypeError('`loose`, if provided, must be a boolean');
+	}
+
+	var nonEnumerable = arguments.length > 3 ? arguments[3] : null;
+	var nonWritable = arguments.length > 4 ? arguments[4] : null;
+	var nonConfigurable = arguments.length > 5 ? arguments[5] : null;
+	var loose = arguments.length > 6 ? arguments[6] : false;
+
+	/* @type {false | TypedPropertyDescriptor<unknown>} */
+	var desc = !!gopd && gopd(obj, property);
+
+	if ($defineProperty) {
+		$defineProperty(obj, property, {
+			configurable: nonConfigurable === null && desc ? desc.configurable : !nonConfigurable,
+			enumerable: nonEnumerable === null && desc ? desc.enumerable : !nonEnumerable,
+			value: value,
+			writable: nonWritable === null && desc ? desc.writable : !nonWritable
+		});
+	} else if (loose || (!nonEnumerable && !nonWritable && !nonConfigurable)) {
+		// must fall back to [[Set]], and was not explicitly asked to make non-enumerable, non-writable, or non-configurable
+		obj[property] = value; // eslint-disable-line no-param-reassign
+	} else {
+		throw new $SyntaxError('This environment does not support defining a property as non-configurable, non-writable, or non-enumerable.');
+	}
+};
+
+
+/***/ }),
+
+/***/ 9234:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var keys = __nccwpck_require__(137);
+var hasSymbols = typeof Symbol === 'function' && typeof Symbol('foo') === 'symbol';
+
+var toStr = Object.prototype.toString;
+var concat = Array.prototype.concat;
+var defineDataProperty = __nccwpck_require__(5653);
+
+var isFunction = function (fn) {
+	return typeof fn === 'function' && toStr.call(fn) === '[object Function]';
+};
+
+var supportsDescriptors = __nccwpck_require__(176)();
+
+var defineProperty = function (object, name, value, predicate) {
+	if (name in object) {
+		if (predicate === true) {
+			if (object[name] === value) {
+				return;
+			}
+		} else if (!isFunction(predicate) || !predicate()) {
+			return;
+		}
+	}
+
+	if (supportsDescriptors) {
+		defineDataProperty(object, name, value, true);
+	} else {
+		defineDataProperty(object, name, value);
+	}
+};
+
+var defineProperties = function (object, map) {
+	var predicates = arguments.length > 2 ? arguments[2] : {};
+	var props = keys(map);
+	if (hasSymbols) {
+		props = concat.call(props, Object.getOwnPropertySymbols(map));
+	}
+	for (var i = 0; i < props.length; i += 1) {
+		defineProperty(object, props[i], map[props[i]], predicates[props[i]]);
+	}
+};
+
+defineProperties.supportsDescriptors = !!supportsDescriptors;
+
+module.exports = defineProperties;
+
+
+/***/ }),
+
+/***/ 5284:
+/***/ ((module) => {
+
+// Only Node.JS has a process variable that is of [[Class]] process
+module.exports = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+
+
+/***/ }),
+
 /***/ 1205:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -3536,6 +3730,3898 @@ var eos = function(stream, opts, callback) {
 };
 
 module.exports = eos;
+
+
+/***/ }),
+
+/***/ 6123:
+/***/ ((module) => {
+
+"use strict";
+
+
+/** @type {import('.')} */
+var $defineProperty = Object.defineProperty || false;
+if ($defineProperty) {
+	try {
+		$defineProperty({}, 'a', { value: 1 });
+	} catch (e) {
+		// IE 8 has a broken defineProperty
+		$defineProperty = false;
+	}
+}
+
+module.exports = $defineProperty;
+
+
+/***/ }),
+
+/***/ 5474:
+/***/ ((module) => {
+
+"use strict";
+
+
+/** @type {import('./syntax')} */
+module.exports = SyntaxError;
+
+
+/***/ }),
+
+/***/ 6361:
+/***/ ((module) => {
+
+"use strict";
+
+
+/** @type {import('./type')} */
+module.exports = TypeError;
+
+
+/***/ }),
+
+/***/ 9000:
+/***/ ((module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function _extendableBuiltin(cls) {
+  function ExtendableBuiltin() {
+    cls.apply(this, arguments);
+  }
+
+  ExtendableBuiltin.prototype = Object.create(cls.prototype, {
+    constructor: {
+      value: cls,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    }
+  });
+
+  if (Object.setPrototypeOf) {
+    Object.setPrototypeOf(ExtendableBuiltin, cls);
+  } else {
+    ExtendableBuiltin.__proto__ = cls;
+  }
+
+  return ExtendableBuiltin;
+}
+
+var ExtendableError = function (_extendableBuiltin2) {
+  _inherits(ExtendableError, _extendableBuiltin2);
+
+  function ExtendableError() {
+    var message = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+
+    _classCallCheck(this, ExtendableError);
+
+    // extending Error is weird and does not propagate `message`
+    var _this = _possibleConstructorReturn(this, (ExtendableError.__proto__ || Object.getPrototypeOf(ExtendableError)).call(this, message));
+
+    Object.defineProperty(_this, 'message', {
+      configurable: true,
+      enumerable: false,
+      value: message,
+      writable: true
+    });
+
+    Object.defineProperty(_this, 'name', {
+      configurable: true,
+      enumerable: false,
+      value: _this.constructor.name,
+      writable: true
+    });
+
+    if (Error.hasOwnProperty('captureStackTrace')) {
+      Error.captureStackTrace(_this, _this.constructor);
+      return _possibleConstructorReturn(_this);
+    }
+
+    Object.defineProperty(_this, 'stack', {
+      configurable: true,
+      enumerable: false,
+      value: new Error(message).stack,
+      writable: true
+    });
+    return _this;
+  }
+
+  return ExtendableError;
+}(_extendableBuiltin(Error));
+
+exports["default"] = ExtendableError;
+module.exports = exports['default'];
+
+
+/***/ }),
+
+/***/ 8528:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _roarr = _interopRequireDefault(__nccwpck_require__(5191));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const Logger = _roarr.default.child({
+  package: 'global-agent'
+});
+
+var _default = Logger;
+exports["default"] = _default;
+//# sourceMappingURL=Logger.js.map
+
+/***/ }),
+
+/***/ 1986:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _serializeError = __nccwpck_require__(8604);
+
+var _boolean = __nccwpck_require__(1253);
+
+var _Logger = _interopRequireDefault(__nccwpck_require__(8528));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const log = _Logger.default.child({
+  namespace: 'Agent'
+});
+
+let requestId = 0;
+
+class Agent {
+  constructor(isProxyConfigured, mustUrlUseProxy, getUrlProxy, fallbackAgent, socketConnectionTimeout) {
+    this.fallbackAgent = fallbackAgent;
+    this.isProxyConfigured = isProxyConfigured;
+    this.mustUrlUseProxy = mustUrlUseProxy;
+    this.getUrlProxy = getUrlProxy;
+    this.socketConnectionTimeout = socketConnectionTimeout;
+  }
+
+  addRequest(request, configuration) {
+    let requestUrl; // It is possible that addRequest was constructed for a proxied request already, e.g.
+    // "request" package does this when it detects that a proxy should be used
+    // https://github.com/request/request/blob/212570b6971a732b8dd9f3c73354bcdda158a737/request.js#L402
+    // https://gist.github.com/gajus/e2074cd3b747864ffeaabbd530d30218
+
+    if (request.path.startsWith('http://') || request.path.startsWith('https://')) {
+      requestUrl = request.path;
+    } else {
+      requestUrl = this.protocol + '//' + (configuration.hostname || configuration.host) + (configuration.port === 80 || configuration.port === 443 ? '' : ':' + configuration.port) + request.path;
+    }
+
+    if (!this.isProxyConfigured()) {
+      log.trace({
+        destination: requestUrl
+      }, 'not proxying request; GLOBAL_AGENT.HTTP_PROXY is not configured'); // $FlowFixMe It appears that Flow is missing the method description.
+
+      this.fallbackAgent.addRequest(request, configuration);
+      return;
+    }
+
+    if (!this.mustUrlUseProxy(requestUrl)) {
+      log.trace({
+        destination: requestUrl
+      }, 'not proxying request; url matches GLOBAL_AGENT.NO_PROXY'); // $FlowFixMe It appears that Flow is missing the method description.
+
+      this.fallbackAgent.addRequest(request, configuration);
+      return;
+    }
+
+    const currentRequestId = requestId++;
+    const proxy = this.getUrlProxy(requestUrl);
+
+    if (this.protocol === 'http:') {
+      request.path = requestUrl;
+
+      if (proxy.authorization) {
+        request.setHeader('proxy-authorization', 'Basic ' + Buffer.from(proxy.authorization).toString('base64'));
+      }
+    }
+
+    log.trace({
+      destination: requestUrl,
+      proxy: 'http://' + proxy.hostname + ':' + proxy.port,
+      requestId: currentRequestId
+    }, 'proxying request');
+    request.on('error', error => {
+      log.error({
+        error: (0, _serializeError.serializeError)(error)
+      }, 'request error');
+    });
+    request.once('response', response => {
+      log.trace({
+        headers: response.headers,
+        requestId: currentRequestId,
+        statusCode: response.statusCode
+      }, 'proxying response');
+    });
+    request.shouldKeepAlive = false;
+    const connectionConfiguration = {
+      host: configuration.hostname || configuration.host,
+      port: configuration.port || 80,
+      proxy,
+      tls: {}
+    }; // add optional tls options for https requests.
+    // @see https://nodejs.org/docs/latest-v12.x/api/https.html#https_https_request_url_options_callback :
+    // > The following additional options from tls.connect()
+    // >   - https://nodejs.org/docs/latest-v12.x/api/tls.html#tls_tls_connect_options_callback -
+    // > are also accepted:
+    // >   ca, cert, ciphers, clientCertEngine, crl, dhparam, ecdhCurve, honorCipherOrder,
+    // >   key, passphrase, pfx, rejectUnauthorized, secureOptions, secureProtocol, servername, sessionIdContext.
+
+    if (this.protocol === 'https:') {
+      connectionConfiguration.tls = {
+        ca: configuration.ca,
+        cert: configuration.cert,
+        ciphers: configuration.ciphers,
+        clientCertEngine: configuration.clientCertEngine,
+        crl: configuration.crl,
+        dhparam: configuration.dhparam,
+        ecdhCurve: configuration.ecdhCurve,
+        honorCipherOrder: configuration.honorCipherOrder,
+        key: configuration.key,
+        passphrase: configuration.passphrase,
+        pfx: configuration.pfx,
+        rejectUnauthorized: configuration.rejectUnauthorized,
+        secureOptions: configuration.secureOptions,
+        secureProtocol: configuration.secureProtocol,
+        servername: configuration.servername || connectionConfiguration.host,
+        sessionIdContext: configuration.sessionIdContext
+      }; // This is not ideal because there is no way to override this setting using `tls` configuration if `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+      // However, popular HTTP clients (such as https://github.com/sindresorhus/got) come with pre-configured value for `rejectUnauthorized`,
+      // which makes it impossible to override that value globally and respect `rejectUnauthorized` for specific requests only.
+      //
+      // eslint-disable-next-line no-process-env
+
+      if (typeof process.env.NODE_TLS_REJECT_UNAUTHORIZED === 'string' && (0, _boolean.boolean)(process.env.NODE_TLS_REJECT_UNAUTHORIZED) === false) {
+        connectionConfiguration.tls.rejectUnauthorized = false;
+      }
+    } // $FlowFixMe It appears that Flow is missing the method description.
+
+
+    this.createConnection(connectionConfiguration, (error, socket) => {
+      log.trace({
+        target: connectionConfiguration
+      }, 'connecting'); // @see https://github.com/nodejs/node/issues/5757#issuecomment-305969057
+
+      if (socket) {
+        socket.setTimeout(this.socketConnectionTimeout, () => {
+          socket.destroy();
+        });
+        socket.once('connect', () => {
+          log.trace({
+            target: connectionConfiguration
+          }, 'connected');
+          socket.setTimeout(0);
+        });
+        socket.once('secureConnect', () => {
+          log.trace({
+            target: connectionConfiguration
+          }, 'connected (secure)');
+          socket.setTimeout(0);
+        });
+      }
+
+      if (error) {
+        request.emit('error', error);
+      } else {
+        log.debug('created socket');
+        socket.on('error', socketError => {
+          log.error({
+            error: (0, _serializeError.serializeError)(socketError)
+          }, 'socket error');
+        });
+        request.onSocket(socket);
+      }
+    });
+  }
+
+}
+
+var _default = Agent;
+exports["default"] = _default;
+//# sourceMappingURL=Agent.js.map
+
+/***/ }),
+
+/***/ 9066:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _net = _interopRequireDefault(__nccwpck_require__(1808));
+
+var _Agent = _interopRequireDefault(__nccwpck_require__(1986));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+class HttpProxyAgent extends _Agent.default {
+  // @see https://github.com/sindresorhus/eslint-plugin-unicorn/issues/169#issuecomment-486980290
+  // eslint-disable-next-line unicorn/prevent-abbreviations
+  constructor(...args) {
+    super(...args);
+    this.protocol = 'http:';
+    this.defaultPort = 80;
+  }
+
+  createConnection(configuration, callback) {
+    const socket = _net.default.connect(configuration.proxy.port, configuration.proxy.hostname);
+
+    callback(null, socket);
+  }
+
+}
+
+var _default = HttpProxyAgent;
+exports["default"] = _default;
+//# sourceMappingURL=HttpProxyAgent.js.map
+
+/***/ }),
+
+/***/ 632:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _net = _interopRequireDefault(__nccwpck_require__(1808));
+
+var _tls = _interopRequireDefault(__nccwpck_require__(4404));
+
+var _Agent = _interopRequireDefault(__nccwpck_require__(1986));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+class HttpsProxyAgent extends _Agent.default {
+  // eslint-disable-next-line unicorn/prevent-abbreviations
+  constructor(...args) {
+    super(...args);
+    this.protocol = 'https:';
+    this.defaultPort = 443;
+  }
+
+  createConnection(configuration, callback) {
+    const socket = _net.default.connect(configuration.proxy.port, configuration.proxy.hostname);
+
+    socket.on('error', error => {
+      callback(error);
+    });
+    socket.once('data', () => {
+      const secureSocket = _tls.default.connect({ ...configuration.tls,
+        socket
+      });
+
+      callback(null, secureSocket);
+    });
+    let connectMessage = '';
+    connectMessage += 'CONNECT ' + configuration.host + ':' + configuration.port + ' HTTP/1.1\r\n';
+    connectMessage += 'Host: ' + configuration.host + ':' + configuration.port + '\r\n';
+
+    if (configuration.proxy.authorization) {
+      connectMessage += 'Proxy-Authorization: Basic ' + Buffer.from(configuration.proxy.authorization).toString('base64') + '\r\n';
+    }
+
+    connectMessage += '\r\n';
+    socket.write(connectMessage);
+  }
+
+}
+
+var _default = HttpsProxyAgent;
+exports["default"] = _default;
+//# sourceMappingURL=HttpsProxyAgent.js.map
+
+/***/ }),
+
+/***/ 8062:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "Agent", ({
+  enumerable: true,
+  get: function () {
+    return _Agent.default;
+  }
+}));
+Object.defineProperty(exports, "HttpProxyAgent", ({
+  enumerable: true,
+  get: function () {
+    return _HttpProxyAgent.default;
+  }
+}));
+Object.defineProperty(exports, "HttpsProxyAgent", ({
+  enumerable: true,
+  get: function () {
+    return _HttpsProxyAgent.default;
+  }
+}));
+
+var _Agent = _interopRequireDefault(__nccwpck_require__(1986));
+
+var _HttpProxyAgent = _interopRequireDefault(__nccwpck_require__(9066));
+
+var _HttpsProxyAgent = _interopRequireDefault(__nccwpck_require__(632));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 9745:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.UnexpectedStateError = void 0;
+
+var _es6Error = _interopRequireDefault(__nccwpck_require__(9000));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/* eslint-disable fp/no-class, fp/no-this */
+class UnexpectedStateError extends _es6Error.default {
+  constructor(message, code = 'UNEXPECTED_STATE_ERROR') {
+    super(message);
+    this.code = code;
+  }
+
+}
+
+exports.UnexpectedStateError = UnexpectedStateError;
+//# sourceMappingURL=errors.js.map
+
+/***/ }),
+
+/***/ 5081:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _http = _interopRequireDefault(__nccwpck_require__(3685));
+
+var _https = _interopRequireDefault(__nccwpck_require__(5687));
+
+var _boolean = __nccwpck_require__(1253);
+
+var _semver = _interopRequireDefault(__nccwpck_require__(4038));
+
+var _Logger = _interopRequireDefault(__nccwpck_require__(8528));
+
+var _classes = __nccwpck_require__(8062);
+
+var _errors = __nccwpck_require__(9745);
+
+var _utilities = __nccwpck_require__(9170);
+
+var _createProxyController = _interopRequireDefault(__nccwpck_require__(5043));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const httpGet = _http.default.get;
+const httpRequest = _http.default.request;
+const httpsGet = _https.default.get;
+const httpsRequest = _https.default.request;
+
+const log = _Logger.default.child({
+  namespace: 'createGlobalProxyAgent'
+});
+
+const defaultConfigurationInput = {
+  environmentVariableNamespace: undefined,
+  forceGlobalAgent: undefined,
+  socketConnectionTimeout: 60000
+};
+
+const omitUndefined = subject => {
+  const keys = Object.keys(subject);
+  const result = {};
+
+  for (const key of keys) {
+    const value = subject[key];
+
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+};
+
+const createConfiguration = configurationInput => {
+  // eslint-disable-next-line no-process-env
+  const environment = process.env;
+  const defaultConfiguration = {
+    environmentVariableNamespace: typeof environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE === 'string' ? environment.GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE : 'GLOBAL_AGENT_',
+    forceGlobalAgent: typeof environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT === 'string' ? (0, _boolean.boolean)(environment.GLOBAL_AGENT_FORCE_GLOBAL_AGENT) : true,
+    socketConnectionTimeout: typeof environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT === 'string' ? Number.parseInt(environment.GLOBAL_AGENT_SOCKET_CONNECTION_TIMEOUT, 10) : defaultConfigurationInput.socketConnectionTimeout
+  }; // $FlowFixMe
+
+  return { ...defaultConfiguration,
+    ...omitUndefined(configurationInput)
+  };
+};
+
+const createGlobalProxyAgent = (configurationInput = defaultConfigurationInput) => {
+  const configuration = createConfiguration(configurationInput);
+  const proxyController = (0, _createProxyController.default)(); // eslint-disable-next-line no-process-env
+
+  proxyController.HTTP_PROXY = process.env[configuration.environmentVariableNamespace + 'HTTP_PROXY'] || null; // eslint-disable-next-line no-process-env
+
+  proxyController.HTTPS_PROXY = process.env[configuration.environmentVariableNamespace + 'HTTPS_PROXY'] || null; // eslint-disable-next-line no-process-env
+
+  proxyController.NO_PROXY = process.env[configuration.environmentVariableNamespace + 'NO_PROXY'] || null;
+  log.info({
+    configuration,
+    state: proxyController
+  }, 'global agent has been initialized');
+
+  const mustUrlUseProxy = getProxy => {
+    return url => {
+      if (!getProxy()) {
+        return false;
+      }
+
+      if (!proxyController.NO_PROXY) {
+        return true;
+      }
+
+      return !(0, _utilities.isUrlMatchingNoProxy)(url, proxyController.NO_PROXY);
+    };
+  };
+
+  const getUrlProxy = getProxy => {
+    return () => {
+      const proxy = getProxy();
+
+      if (!proxy) {
+        throw new _errors.UnexpectedStateError('HTTP(S) proxy must be configured.');
+      }
+
+      return (0, _utilities.parseProxyUrl)(proxy);
+    };
+  };
+
+  const getHttpProxy = () => {
+    return proxyController.HTTP_PROXY;
+  };
+
+  const BoundHttpProxyAgent = class extends _classes.HttpProxyAgent {
+    constructor() {
+      super(() => {
+        return getHttpProxy();
+      }, mustUrlUseProxy(getHttpProxy), getUrlProxy(getHttpProxy), _http.default.globalAgent, configuration.socketConnectionTimeout);
+    }
+
+  };
+  const httpAgent = new BoundHttpProxyAgent();
+
+  const getHttpsProxy = () => {
+    return proxyController.HTTPS_PROXY || proxyController.HTTP_PROXY;
+  };
+
+  const BoundHttpsProxyAgent = class extends _classes.HttpsProxyAgent {
+    constructor() {
+      super(() => {
+        return getHttpsProxy();
+      }, mustUrlUseProxy(getHttpsProxy), getUrlProxy(getHttpsProxy), _https.default.globalAgent, configuration.socketConnectionTimeout);
+    }
+
+  };
+  const httpsAgent = new BoundHttpsProxyAgent(); // Overriding globalAgent was added in v11.7.
+  // @see https://nodejs.org/uk/blog/release/v11.7.0/
+
+  if (_semver.default.gte(process.version, 'v11.7.0')) {
+    // @see https://github.com/facebook/flow/issues/7670
+    // $FlowFixMe
+    _http.default.globalAgent = httpAgent; // $FlowFixMe
+
+    _https.default.globalAgent = httpsAgent;
+  } // The reason this logic is used in addition to overriding http(s).globalAgent
+  // is because there is no guarantee that we set http(s).globalAgent variable
+  // before an instance of http(s).Agent has been already constructed by someone,
+  // e.g. Stripe SDK creates instances of http(s).Agent at the top-level.
+  // @see https://github.com/gajus/global-agent/pull/13
+  //
+  // We still want to override http(s).globalAgent when possible to enable logic
+  // in `bindHttpMethod`.
+
+
+  if (_semver.default.gte(process.version, 'v10.0.0')) {
+    // $FlowFixMe
+    _http.default.get = (0, _utilities.bindHttpMethod)(httpGet, httpAgent, configuration.forceGlobalAgent); // $FlowFixMe
+
+    _http.default.request = (0, _utilities.bindHttpMethod)(httpRequest, httpAgent, configuration.forceGlobalAgent); // $FlowFixMe
+
+    _https.default.get = (0, _utilities.bindHttpMethod)(httpsGet, httpsAgent, configuration.forceGlobalAgent); // $FlowFixMe
+
+    _https.default.request = (0, _utilities.bindHttpMethod)(httpsRequest, httpsAgent, configuration.forceGlobalAgent);
+  } else {
+    log.warn('attempt to initialize global-agent in unsupported Node.js version was ignored');
+  }
+
+  return proxyController;
+};
+
+var _default = createGlobalProxyAgent;
+exports["default"] = _default;
+//# sourceMappingURL=createGlobalProxyAgent.js.map
+
+/***/ }),
+
+/***/ 5043:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _Logger = _interopRequireDefault(__nccwpck_require__(8528));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const log = _Logger.default.child({
+  namespace: 'createProxyController'
+});
+
+const KNOWN_PROPERTY_NAMES = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
+
+const createProxyController = () => {
+  // eslint-disable-next-line fp/no-proxy
+  return new Proxy({
+    HTTP_PROXY: null,
+    HTTPS_PROXY: null,
+    NO_PROXY: null
+  }, {
+    set: (subject, name, value) => {
+      if (!KNOWN_PROPERTY_NAMES.includes(name)) {
+        throw new Error('Cannot set an unmapped property "' + name + '".');
+      }
+
+      subject[name] = value;
+      log.info({
+        change: {
+          name,
+          value
+        },
+        newConfiguration: subject
+      }, 'configuration changed');
+      return true;
+    }
+  });
+};
+
+var _default = createProxyController;
+exports["default"] = _default;
+//# sourceMappingURL=createProxyController.js.map
+
+/***/ }),
+
+/***/ 5480:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "createGlobalProxyAgent", ({
+  enumerable: true,
+  get: function () {
+    return _createGlobalProxyAgent.default;
+  }
+}));
+Object.defineProperty(exports, "createProxyController", ({
+  enumerable: true,
+  get: function () {
+    return _createProxyController.default;
+  }
+}));
+
+var _createGlobalProxyAgent = _interopRequireDefault(__nccwpck_require__(5081));
+
+var _createProxyController = _interopRequireDefault(__nccwpck_require__(5043));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 6769:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "bootstrap", ({
+  enumerable: true,
+  get: function () {
+    return _routines.bootstrap;
+  }
+}));
+Object.defineProperty(exports, "createGlobalProxyAgent", ({
+  enumerable: true,
+  get: function () {
+    return _factories.createGlobalProxyAgent;
+  }
+}));
+
+var _routines = __nccwpck_require__(715);
+
+var _factories = __nccwpck_require__(5480);
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 8259:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _Logger = _interopRequireDefault(__nccwpck_require__(8528));
+
+var _factories = __nccwpck_require__(5480);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const log = _Logger.default.child({
+  namespace: 'bootstrap'
+});
+
+const bootstrap = configurationInput => {
+  if (global.GLOBAL_AGENT) {
+    log.warn('found global.GLOBAL_AGENT; second attempt to bootstrap global-agent was ignored');
+    return false;
+  }
+
+  global.GLOBAL_AGENT = (0, _factories.createGlobalProxyAgent)(configurationInput);
+  return true;
+};
+
+var _default = bootstrap;
+exports["default"] = _default;
+//# sourceMappingURL=bootstrap.js.map
+
+/***/ }),
+
+/***/ 715:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "bootstrap", ({
+  enumerable: true,
+  get: function () {
+    return _bootstrap.default;
+  }
+}));
+
+var _bootstrap = _interopRequireDefault(__nccwpck_require__(8259));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 8754:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _http = _interopRequireDefault(__nccwpck_require__(3685));
+
+var _https = _interopRequireDefault(__nccwpck_require__(5687));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// eslint-disable-next-line flowtype/no-weak-types
+const bindHttpMethod = (originalMethod, agent, forceGlobalAgent) => {
+  // eslint-disable-next-line unicorn/prevent-abbreviations
+  return (...args) => {
+    let url;
+    let options;
+    let callback;
+
+    if (typeof args[0] === 'string' || args[0] instanceof URL) {
+      url = args[0];
+
+      if (typeof args[1] === 'function') {
+        options = {};
+        callback = args[1];
+      } else {
+        options = { ...args[1]
+        };
+        callback = args[2];
+      }
+    } else {
+      options = { ...args[0]
+      };
+      callback = args[1];
+    }
+
+    if (forceGlobalAgent) {
+      options.agent = agent;
+    } else {
+      if (!options.agent) {
+        options.agent = agent;
+      }
+
+      if (options.agent === _http.default.globalAgent || options.agent === _https.default.globalAgent) {
+        options.agent = agent;
+      }
+    }
+
+    if (url) {
+      // $FlowFixMe
+      return originalMethod(url, options, callback);
+    } else {
+      return originalMethod(options, callback);
+    }
+  };
+};
+
+var _default = bindHttpMethod;
+exports["default"] = _default;
+//# sourceMappingURL=bindHttpMethod.js.map
+
+/***/ }),
+
+/***/ 9170:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "bindHttpMethod", ({
+  enumerable: true,
+  get: function () {
+    return _bindHttpMethod.default;
+  }
+}));
+Object.defineProperty(exports, "isUrlMatchingNoProxy", ({
+  enumerable: true,
+  get: function () {
+    return _isUrlMatchingNoProxy.default;
+  }
+}));
+Object.defineProperty(exports, "parseProxyUrl", ({
+  enumerable: true,
+  get: function () {
+    return _parseProxyUrl.default;
+  }
+}));
+
+var _bindHttpMethod = _interopRequireDefault(__nccwpck_require__(8754));
+
+var _isUrlMatchingNoProxy = _interopRequireDefault(__nccwpck_require__(346));
+
+var _parseProxyUrl = _interopRequireDefault(__nccwpck_require__(4395));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 346:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _url = __nccwpck_require__(7310);
+
+var _matcher = _interopRequireDefault(__nccwpck_require__(2239));
+
+var _errors = __nccwpck_require__(9745);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const isUrlMatchingNoProxy = (subjectUrl, noProxy) => {
+  const subjectUrlTokens = (0, _url.parse)(subjectUrl);
+  const rules = noProxy.split(/[\s,]+/);
+
+  for (const rule of rules) {
+    const ruleMatch = rule.replace(/^(?<leadingDot>\.)/, '*').match(/^(?<hostname>.+?)(?::(?<port>\d+))?$/);
+
+    if (!ruleMatch || !ruleMatch.groups) {
+      throw new _errors.UnexpectedStateError('Invalid NO_PROXY pattern.');
+    }
+
+    if (!ruleMatch.groups.hostname) {
+      throw new _errors.UnexpectedStateError('NO_PROXY entry pattern must include hostname. Use * to match any hostname.');
+    }
+
+    const hostnameIsMatch = _matcher.default.isMatch(subjectUrlTokens.hostname, ruleMatch.groups.hostname);
+
+    if (hostnameIsMatch && (!ruleMatch.groups || !ruleMatch.groups.port || subjectUrlTokens.port && subjectUrlTokens.port === ruleMatch.groups.port)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+var _default = isUrlMatchingNoProxy;
+exports["default"] = _default;
+//# sourceMappingURL=isUrlMatchingNoProxy.js.map
+
+/***/ }),
+
+/***/ 4395:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _url = __nccwpck_require__(7310);
+
+var _errors = __nccwpck_require__(9745);
+
+const parseProxyUrl = url => {
+  const urlTokens = (0, _url.parse)(url);
+
+  if (urlTokens.query !== null) {
+    throw new _errors.UnexpectedStateError('Unsupported `GLOBAL_AGENT.HTTP_PROXY` configuration value: URL must not have query.');
+  }
+
+  if (urlTokens.hash !== null) {
+    throw new _errors.UnexpectedStateError('Unsupported `GLOBAL_AGENT.HTTP_PROXY` configuration value: URL must not have hash.');
+  }
+
+  if (urlTokens.protocol !== 'http:') {
+    throw new _errors.UnexpectedStateError('Unsupported `GLOBAL_AGENT.HTTP_PROXY` configuration value: URL protocol must be "http:".');
+  }
+
+  let port = 80;
+
+  if (urlTokens.port) {
+    port = Number.parseInt(urlTokens.port, 10);
+  }
+
+  return {
+    authorization: urlTokens.auth || null,
+    hostname: urlTokens.hostname,
+    port
+  };
+};
+
+var _default = parseProxyUrl;
+exports["default"] = _default;
+//# sourceMappingURL=parseProxyUrl.js.map
+
+/***/ }),
+
+/***/ 8106:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const ANY = Symbol('SemVer ANY')
+// hoisted class for cyclic dependency
+class Comparator {
+  static get ANY () {
+    return ANY
+  }
+
+  constructor (comp, options) {
+    options = parseOptions(options)
+
+    if (comp instanceof Comparator) {
+      if (comp.loose === !!options.loose) {
+        return comp
+      } else {
+        comp = comp.value
+      }
+    }
+
+    comp = comp.trim().split(/\s+/).join(' ')
+    debug('comparator', comp, options)
+    this.options = options
+    this.loose = !!options.loose
+    this.parse(comp)
+
+    if (this.semver === ANY) {
+      this.value = ''
+    } else {
+      this.value = this.operator + this.semver.version
+    }
+
+    debug('comp', this)
+  }
+
+  parse (comp) {
+    const r = this.options.loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR]
+    const m = comp.match(r)
+
+    if (!m) {
+      throw new TypeError(`Invalid comparator: ${comp}`)
+    }
+
+    this.operator = m[1] !== undefined ? m[1] : ''
+    if (this.operator === '=') {
+      this.operator = ''
+    }
+
+    // if it literally is just '>' or '' then allow anything.
+    if (!m[2]) {
+      this.semver = ANY
+    } else {
+      this.semver = new SemVer(m[2], this.options.loose)
+    }
+  }
+
+  toString () {
+    return this.value
+  }
+
+  test (version) {
+    debug('Comparator.test', version, this.options.loose)
+
+    if (this.semver === ANY || version === ANY) {
+      return true
+    }
+
+    if (typeof version === 'string') {
+      try {
+        version = new SemVer(version, this.options)
+      } catch (er) {
+        return false
+      }
+    }
+
+    return cmp(version, this.operator, this.semver, this.options)
+  }
+
+  intersects (comp, options) {
+    if (!(comp instanceof Comparator)) {
+      throw new TypeError('a Comparator is required')
+    }
+
+    if (this.operator === '') {
+      if (this.value === '') {
+        return true
+      }
+      return new Range(comp.value, options).test(this.value)
+    } else if (comp.operator === '') {
+      if (comp.value === '') {
+        return true
+      }
+      return new Range(this.value, options).test(comp.semver)
+    }
+
+    options = parseOptions(options)
+
+    // Special cases where nothing can possibly be lower
+    if (options.includePrerelease &&
+      (this.value === '<0.0.0-0' || comp.value === '<0.0.0-0')) {
+      return false
+    }
+    if (!options.includePrerelease &&
+      (this.value.startsWith('<0.0.0') || comp.value.startsWith('<0.0.0'))) {
+      return false
+    }
+
+    // Same direction increasing (> or >=)
+    if (this.operator.startsWith('>') && comp.operator.startsWith('>')) {
+      return true
+    }
+    // Same direction decreasing (< or <=)
+    if (this.operator.startsWith('<') && comp.operator.startsWith('<')) {
+      return true
+    }
+    // same SemVer and both sides are inclusive (<= or >=)
+    if (
+      (this.semver.version === comp.semver.version) &&
+      this.operator.includes('=') && comp.operator.includes('=')) {
+      return true
+    }
+    // opposite directions less than
+    if (cmp(this.semver, '<', comp.semver, options) &&
+      this.operator.startsWith('>') && comp.operator.startsWith('<')) {
+      return true
+    }
+    // opposite directions greater than
+    if (cmp(this.semver, '>', comp.semver, options) &&
+      this.operator.startsWith('<') && comp.operator.startsWith('>')) {
+      return true
+    }
+    return false
+  }
+}
+
+module.exports = Comparator
+
+const parseOptions = __nccwpck_require__(7371)
+const { safeRe: re, t } = __nccwpck_require__(6154)
+const cmp = __nccwpck_require__(3210)
+const debug = __nccwpck_require__(1858)
+const SemVer = __nccwpck_require__(2614)
+const Range = __nccwpck_require__(4506)
+
+
+/***/ }),
+
+/***/ 4506:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SPACE_CHARACTERS = /\s+/g
+
+// hoisted class for cyclic dependency
+class Range {
+  constructor (range, options) {
+    options = parseOptions(options)
+
+    if (range instanceof Range) {
+      if (
+        range.loose === !!options.loose &&
+        range.includePrerelease === !!options.includePrerelease
+      ) {
+        return range
+      } else {
+        return new Range(range.raw, options)
+      }
+    }
+
+    if (range instanceof Comparator) {
+      // just put it in the set and return
+      this.raw = range.value
+      this.set = [[range]]
+      this.formatted = undefined
+      return this
+    }
+
+    this.options = options
+    this.loose = !!options.loose
+    this.includePrerelease = !!options.includePrerelease
+
+    // First reduce all whitespace as much as possible so we do not have to rely
+    // on potentially slow regexes like \s*. This is then stored and used for
+    // future error messages as well.
+    this.raw = range.trim().replace(SPACE_CHARACTERS, ' ')
+
+    // First, split on ||
+    this.set = this.raw
+      .split('||')
+      // map the range to a 2d array of comparators
+      .map(r => this.parseRange(r.trim()))
+      // throw out any comparator lists that are empty
+      // this generally means that it was not a valid range, which is allowed
+      // in loose mode, but will still throw if the WHOLE range is invalid.
+      .filter(c => c.length)
+
+    if (!this.set.length) {
+      throw new TypeError(`Invalid SemVer Range: ${this.raw}`)
+    }
+
+    // if we have any that are not the null set, throw out null sets.
+    if (this.set.length > 1) {
+      // keep the first one, in case they're all null sets
+      const first = this.set[0]
+      this.set = this.set.filter(c => !isNullSet(c[0]))
+      if (this.set.length === 0) {
+        this.set = [first]
+      } else if (this.set.length > 1) {
+        // if we have any that are *, then the range is just *
+        for (const c of this.set) {
+          if (c.length === 1 && isAny(c[0])) {
+            this.set = [c]
+            break
+          }
+        }
+      }
+    }
+
+    this.formatted = undefined
+  }
+
+  get range () {
+    if (this.formatted === undefined) {
+      this.formatted = ''
+      for (let i = 0; i < this.set.length; i++) {
+        if (i > 0) {
+          this.formatted += '||'
+        }
+        const comps = this.set[i]
+        for (let k = 0; k < comps.length; k++) {
+          if (k > 0) {
+            this.formatted += ' '
+          }
+          this.formatted += comps[k].toString().trim()
+        }
+      }
+    }
+    return this.formatted
+  }
+
+  format () {
+    return this.range
+  }
+
+  toString () {
+    return this.range
+  }
+
+  parseRange (range) {
+    // memoize range parsing for performance.
+    // this is a very hot path, and fully deterministic.
+    const memoOpts =
+      (this.options.includePrerelease && FLAG_INCLUDE_PRERELEASE) |
+      (this.options.loose && FLAG_LOOSE)
+    const memoKey = memoOpts + ':' + range
+    const cached = cache.get(memoKey)
+    if (cached) {
+      return cached
+    }
+
+    const loose = this.options.loose
+    // `1.2.3 - 1.2.4` => `>=1.2.3 <=1.2.4`
+    const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE]
+    range = range.replace(hr, hyphenReplace(this.options.includePrerelease))
+    debug('hyphen replace', range)
+
+    // `> 1.2.3 < 1.2.5` => `>1.2.3 <1.2.5`
+    range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace)
+    debug('comparator trim', range)
+
+    // `~ 1.2.3` => `~1.2.3`
+    range = range.replace(re[t.TILDETRIM], tildeTrimReplace)
+    debug('tilde trim', range)
+
+    // `^ 1.2.3` => `^1.2.3`
+    range = range.replace(re[t.CARETTRIM], caretTrimReplace)
+    debug('caret trim', range)
+
+    // At this point, the range is completely trimmed and
+    // ready to be split into comparators.
+
+    let rangeList = range
+      .split(' ')
+      .map(comp => parseComparator(comp, this.options))
+      .join(' ')
+      .split(/\s+/)
+      // >=0.0.0 is equivalent to *
+      .map(comp => replaceGTE0(comp, this.options))
+
+    if (loose) {
+      // in loose mode, throw out any that are not valid comparators
+      rangeList = rangeList.filter(comp => {
+        debug('loose invalid filter', comp, this.options)
+        return !!comp.match(re[t.COMPARATORLOOSE])
+      })
+    }
+    debug('range list', rangeList)
+
+    // if any comparators are the null set, then replace with JUST null set
+    // if more than one comparator, remove any * comparators
+    // also, don't include the same comparator more than once
+    const rangeMap = new Map()
+    const comparators = rangeList.map(comp => new Comparator(comp, this.options))
+    for (const comp of comparators) {
+      if (isNullSet(comp)) {
+        return [comp]
+      }
+      rangeMap.set(comp.value, comp)
+    }
+    if (rangeMap.size > 1 && rangeMap.has('')) {
+      rangeMap.delete('')
+    }
+
+    const result = [...rangeMap.values()]
+    cache.set(memoKey, result)
+    return result
+  }
+
+  intersects (range, options) {
+    if (!(range instanceof Range)) {
+      throw new TypeError('a Range is required')
+    }
+
+    return this.set.some((thisComparators) => {
+      return (
+        isSatisfiable(thisComparators, options) &&
+        range.set.some((rangeComparators) => {
+          return (
+            isSatisfiable(rangeComparators, options) &&
+            thisComparators.every((thisComparator) => {
+              return rangeComparators.every((rangeComparator) => {
+                return thisComparator.intersects(rangeComparator, options)
+              })
+            })
+          )
+        })
+      )
+    })
+  }
+
+  // if ANY of the sets match ALL of its comparators, then pass
+  test (version) {
+    if (!version) {
+      return false
+    }
+
+    if (typeof version === 'string') {
+      try {
+        version = new SemVer(version, this.options)
+      } catch (er) {
+        return false
+      }
+    }
+
+    for (let i = 0; i < this.set.length; i++) {
+      if (testSet(this.set[i], version, this.options)) {
+        return true
+      }
+    }
+    return false
+  }
+}
+
+module.exports = Range
+
+const LRU = __nccwpck_require__(520)
+const cache = new LRU()
+
+const parseOptions = __nccwpck_require__(7371)
+const Comparator = __nccwpck_require__(8106)
+const debug = __nccwpck_require__(1858)
+const SemVer = __nccwpck_require__(2614)
+const {
+  safeRe: re,
+  t,
+  comparatorTrimReplace,
+  tildeTrimReplace,
+  caretTrimReplace,
+} = __nccwpck_require__(6154)
+const { FLAG_INCLUDE_PRERELEASE, FLAG_LOOSE } = __nccwpck_require__(3285)
+
+const isNullSet = c => c.value === '<0.0.0-0'
+const isAny = c => c.value === ''
+
+// take a set of comparators and determine whether there
+// exists a version which can satisfy it
+const isSatisfiable = (comparators, options) => {
+  let result = true
+  const remainingComparators = comparators.slice()
+  let testComparator = remainingComparators.pop()
+
+  while (result && remainingComparators.length) {
+    result = remainingComparators.every((otherComparator) => {
+      return testComparator.intersects(otherComparator, options)
+    })
+
+    testComparator = remainingComparators.pop()
+  }
+
+  return result
+}
+
+// comprised of xranges, tildes, stars, and gtlt's at this point.
+// already replaced the hyphen ranges
+// turn into a set of JUST comparators.
+const parseComparator = (comp, options) => {
+  debug('comp', comp, options)
+  comp = replaceCarets(comp, options)
+  debug('caret', comp)
+  comp = replaceTildes(comp, options)
+  debug('tildes', comp)
+  comp = replaceXRanges(comp, options)
+  debug('xrange', comp)
+  comp = replaceStars(comp, options)
+  debug('stars', comp)
+  return comp
+}
+
+const isX = id => !id || id.toLowerCase() === 'x' || id === '*'
+
+// ~, ~> --> * (any, kinda silly)
+// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0-0
+// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0-0
+// ~1.2, ~1.2.x, ~>1.2, ~>1.2.x --> >=1.2.0 <1.3.0-0
+// ~1.2.3, ~>1.2.3 --> >=1.2.3 <1.3.0-0
+// ~1.2.0, ~>1.2.0 --> >=1.2.0 <1.3.0-0
+// ~0.0.1 --> >=0.0.1 <0.1.0-0
+const replaceTildes = (comp, options) => {
+  return comp
+    .trim()
+    .split(/\s+/)
+    .map((c) => replaceTilde(c, options))
+    .join(' ')
+}
+
+const replaceTilde = (comp, options) => {
+  const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE]
+  return comp.replace(r, (_, M, m, p, pr) => {
+    debug('tilde', comp, _, M, m, p, pr)
+    let ret
+
+    if (isX(M)) {
+      ret = ''
+    } else if (isX(m)) {
+      ret = `>=${M}.0.0 <${+M + 1}.0.0-0`
+    } else if (isX(p)) {
+      // ~1.2 == >=1.2.0 <1.3.0-0
+      ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`
+    } else if (pr) {
+      debug('replaceTilde pr', pr)
+      ret = `>=${M}.${m}.${p}-${pr
+      } <${M}.${+m + 1}.0-0`
+    } else {
+      // ~1.2.3 == >=1.2.3 <1.3.0-0
+      ret = `>=${M}.${m}.${p
+      } <${M}.${+m + 1}.0-0`
+    }
+
+    debug('tilde return', ret)
+    return ret
+  })
+}
+
+// ^ --> * (any, kinda silly)
+// ^2, ^2.x, ^2.x.x --> >=2.0.0 <3.0.0-0
+// ^2.0, ^2.0.x --> >=2.0.0 <3.0.0-0
+// ^1.2, ^1.2.x --> >=1.2.0 <2.0.0-0
+// ^1.2.3 --> >=1.2.3 <2.0.0-0
+// ^1.2.0 --> >=1.2.0 <2.0.0-0
+// ^0.0.1 --> >=0.0.1 <0.0.2-0
+// ^0.1.0 --> >=0.1.0 <0.2.0-0
+const replaceCarets = (comp, options) => {
+  return comp
+    .trim()
+    .split(/\s+/)
+    .map((c) => replaceCaret(c, options))
+    .join(' ')
+}
+
+const replaceCaret = (comp, options) => {
+  debug('caret', comp, options)
+  const r = options.loose ? re[t.CARETLOOSE] : re[t.CARET]
+  const z = options.includePrerelease ? '-0' : ''
+  return comp.replace(r, (_, M, m, p, pr) => {
+    debug('caret', comp, _, M, m, p, pr)
+    let ret
+
+    if (isX(M)) {
+      ret = ''
+    } else if (isX(m)) {
+      ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`
+    } else if (isX(p)) {
+      if (M === '0') {
+        ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`
+      } else {
+        ret = `>=${M}.${m}.0${z} <${+M + 1}.0.0-0`
+      }
+    } else if (pr) {
+      debug('replaceCaret pr', pr)
+      if (M === '0') {
+        if (m === '0') {
+          ret = `>=${M}.${m}.${p}-${pr
+          } <${M}.${m}.${+p + 1}-0`
+        } else {
+          ret = `>=${M}.${m}.${p}-${pr
+          } <${M}.${+m + 1}.0-0`
+        }
+      } else {
+        ret = `>=${M}.${m}.${p}-${pr
+        } <${+M + 1}.0.0-0`
+      }
+    } else {
+      debug('no pr')
+      if (M === '0') {
+        if (m === '0') {
+          ret = `>=${M}.${m}.${p
+          }${z} <${M}.${m}.${+p + 1}-0`
+        } else {
+          ret = `>=${M}.${m}.${p
+          }${z} <${M}.${+m + 1}.0-0`
+        }
+      } else {
+        ret = `>=${M}.${m}.${p
+        } <${+M + 1}.0.0-0`
+      }
+    }
+
+    debug('caret return', ret)
+    return ret
+  })
+}
+
+const replaceXRanges = (comp, options) => {
+  debug('replaceXRanges', comp, options)
+  return comp
+    .split(/\s+/)
+    .map((c) => replaceXRange(c, options))
+    .join(' ')
+}
+
+const replaceXRange = (comp, options) => {
+  comp = comp.trim()
+  const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE]
+  return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
+    debug('xRange', comp, ret, gtlt, M, m, p, pr)
+    const xM = isX(M)
+    const xm = xM || isX(m)
+    const xp = xm || isX(p)
+    const anyX = xp
+
+    if (gtlt === '=' && anyX) {
+      gtlt = ''
+    }
+
+    // if we're including prereleases in the match, then we need
+    // to fix this to -0, the lowest possible prerelease value
+    pr = options.includePrerelease ? '-0' : ''
+
+    if (xM) {
+      if (gtlt === '>' || gtlt === '<') {
+        // nothing is allowed
+        ret = '<0.0.0-0'
+      } else {
+        // nothing is forbidden
+        ret = '*'
+      }
+    } else if (gtlt && anyX) {
+      // we know patch is an x, because we have any x at all.
+      // replace X with 0
+      if (xm) {
+        m = 0
+      }
+      p = 0
+
+      if (gtlt === '>') {
+        // >1 => >=2.0.0
+        // >1.2 => >=1.3.0
+        gtlt = '>='
+        if (xm) {
+          M = +M + 1
+          m = 0
+          p = 0
+        } else {
+          m = +m + 1
+          p = 0
+        }
+      } else if (gtlt === '<=') {
+        // <=0.7.x is actually <0.8.0, since any 0.7.x should
+        // pass.  Similarly, <=7.x is actually <8.0.0, etc.
+        gtlt = '<'
+        if (xm) {
+          M = +M + 1
+        } else {
+          m = +m + 1
+        }
+      }
+
+      if (gtlt === '<') {
+        pr = '-0'
+      }
+
+      ret = `${gtlt + M}.${m}.${p}${pr}`
+    } else if (xm) {
+      ret = `>=${M}.0.0${pr} <${+M + 1}.0.0-0`
+    } else if (xp) {
+      ret = `>=${M}.${m}.0${pr
+      } <${M}.${+m + 1}.0-0`
+    }
+
+    debug('xRange return', ret)
+
+    return ret
+  })
+}
+
+// Because * is AND-ed with everything else in the comparator,
+// and '' means "any version", just remove the *s entirely.
+const replaceStars = (comp, options) => {
+  debug('replaceStars', comp, options)
+  // Looseness is ignored here.  star is always as loose as it gets!
+  return comp
+    .trim()
+    .replace(re[t.STAR], '')
+}
+
+const replaceGTE0 = (comp, options) => {
+  debug('replaceGTE0', comp, options)
+  return comp
+    .trim()
+    .replace(re[options.includePrerelease ? t.GTE0PRE : t.GTE0], '')
+}
+
+// This function is passed to string.replace(re[t.HYPHENRANGE])
+// M, m, patch, prerelease, build
+// 1.2 - 3.4.5 => >=1.2.0 <=3.4.5
+// 1.2.3 - 3.4 => >=1.2.0 <3.5.0-0 Any 3.4.x will do
+// 1.2 - 3.4 => >=1.2.0 <3.5.0-0
+// TODO build?
+const hyphenReplace = incPr => ($0,
+  from, fM, fm, fp, fpr, fb,
+  to, tM, tm, tp, tpr) => {
+  if (isX(fM)) {
+    from = ''
+  } else if (isX(fm)) {
+    from = `>=${fM}.0.0${incPr ? '-0' : ''}`
+  } else if (isX(fp)) {
+    from = `>=${fM}.${fm}.0${incPr ? '-0' : ''}`
+  } else if (fpr) {
+    from = `>=${from}`
+  } else {
+    from = `>=${from}${incPr ? '-0' : ''}`
+  }
+
+  if (isX(tM)) {
+    to = ''
+  } else if (isX(tm)) {
+    to = `<${+tM + 1}.0.0-0`
+  } else if (isX(tp)) {
+    to = `<${tM}.${+tm + 1}.0-0`
+  } else if (tpr) {
+    to = `<=${tM}.${tm}.${tp}-${tpr}`
+  } else if (incPr) {
+    to = `<${tM}.${tm}.${+tp + 1}-0`
+  } else {
+    to = `<=${to}`
+  }
+
+  return `${from} ${to}`.trim()
+}
+
+const testSet = (set, version, options) => {
+  for (let i = 0; i < set.length; i++) {
+    if (!set[i].test(version)) {
+      return false
+    }
+  }
+
+  if (version.prerelease.length && !options.includePrerelease) {
+    // Find the set of versions that are allowed to have prereleases
+    // For example, ^1.2.3-pr.1 desugars to >=1.2.3-pr.1 <2.0.0
+    // That should allow `1.2.3-pr.2` to pass.
+    // However, `1.2.4-alpha.notready` should NOT be allowed,
+    // even though it's within the range set by the comparators.
+    for (let i = 0; i < set.length; i++) {
+      debug(set[i].semver)
+      if (set[i].semver === Comparator.ANY) {
+        continue
+      }
+
+      if (set[i].semver.prerelease.length > 0) {
+        const allowed = set[i].semver
+        if (allowed.major === version.major &&
+            allowed.minor === version.minor &&
+            allowed.patch === version.patch) {
+          return true
+        }
+      }
+    }
+
+    // Version has a -pre, but it's not one of the ones we like.
+    return false
+  }
+
+  return true
+}
+
+
+/***/ }),
+
+/***/ 2614:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const debug = __nccwpck_require__(1858)
+const { MAX_LENGTH, MAX_SAFE_INTEGER } = __nccwpck_require__(3285)
+const { safeRe: re, t } = __nccwpck_require__(6154)
+
+const parseOptions = __nccwpck_require__(7371)
+const { compareIdentifiers } = __nccwpck_require__(8983)
+class SemVer {
+  constructor (version, options) {
+    options = parseOptions(options)
+
+    if (version instanceof SemVer) {
+      if (version.loose === !!options.loose &&
+        version.includePrerelease === !!options.includePrerelease) {
+        return version
+      } else {
+        version = version.version
+      }
+    } else if (typeof version !== 'string') {
+      throw new TypeError(`Invalid version. Must be a string. Got type "${typeof version}".`)
+    }
+
+    if (version.length > MAX_LENGTH) {
+      throw new TypeError(
+        `version is longer than ${MAX_LENGTH} characters`
+      )
+    }
+
+    debug('SemVer', version, options)
+    this.options = options
+    this.loose = !!options.loose
+    // this isn't actually relevant for versions, but keep it so that we
+    // don't run into trouble passing this.options around.
+    this.includePrerelease = !!options.includePrerelease
+
+    const m = version.trim().match(options.loose ? re[t.LOOSE] : re[t.FULL])
+
+    if (!m) {
+      throw new TypeError(`Invalid Version: ${version}`)
+    }
+
+    this.raw = version
+
+    // these are actually numbers
+    this.major = +m[1]
+    this.minor = +m[2]
+    this.patch = +m[3]
+
+    if (this.major > MAX_SAFE_INTEGER || this.major < 0) {
+      throw new TypeError('Invalid major version')
+    }
+
+    if (this.minor > MAX_SAFE_INTEGER || this.minor < 0) {
+      throw new TypeError('Invalid minor version')
+    }
+
+    if (this.patch > MAX_SAFE_INTEGER || this.patch < 0) {
+      throw new TypeError('Invalid patch version')
+    }
+
+    // numberify any prerelease numeric ids
+    if (!m[4]) {
+      this.prerelease = []
+    } else {
+      this.prerelease = m[4].split('.').map((id) => {
+        if (/^[0-9]+$/.test(id)) {
+          const num = +id
+          if (num >= 0 && num < MAX_SAFE_INTEGER) {
+            return num
+          }
+        }
+        return id
+      })
+    }
+
+    this.build = m[5] ? m[5].split('.') : []
+    this.format()
+  }
+
+  format () {
+    this.version = `${this.major}.${this.minor}.${this.patch}`
+    if (this.prerelease.length) {
+      this.version += `-${this.prerelease.join('.')}`
+    }
+    return this.version
+  }
+
+  toString () {
+    return this.version
+  }
+
+  compare (other) {
+    debug('SemVer.compare', this.version, this.options, other)
+    if (!(other instanceof SemVer)) {
+      if (typeof other === 'string' && other === this.version) {
+        return 0
+      }
+      other = new SemVer(other, this.options)
+    }
+
+    if (other.version === this.version) {
+      return 0
+    }
+
+    return this.compareMain(other) || this.comparePre(other)
+  }
+
+  compareMain (other) {
+    if (!(other instanceof SemVer)) {
+      other = new SemVer(other, this.options)
+    }
+
+    return (
+      compareIdentifiers(this.major, other.major) ||
+      compareIdentifiers(this.minor, other.minor) ||
+      compareIdentifiers(this.patch, other.patch)
+    )
+  }
+
+  comparePre (other) {
+    if (!(other instanceof SemVer)) {
+      other = new SemVer(other, this.options)
+    }
+
+    // NOT having a prerelease is > having one
+    if (this.prerelease.length && !other.prerelease.length) {
+      return -1
+    } else if (!this.prerelease.length && other.prerelease.length) {
+      return 1
+    } else if (!this.prerelease.length && !other.prerelease.length) {
+      return 0
+    }
+
+    let i = 0
+    do {
+      const a = this.prerelease[i]
+      const b = other.prerelease[i]
+      debug('prerelease compare', i, a, b)
+      if (a === undefined && b === undefined) {
+        return 0
+      } else if (b === undefined) {
+        return 1
+      } else if (a === undefined) {
+        return -1
+      } else if (a === b) {
+        continue
+      } else {
+        return compareIdentifiers(a, b)
+      }
+    } while (++i)
+  }
+
+  compareBuild (other) {
+    if (!(other instanceof SemVer)) {
+      other = new SemVer(other, this.options)
+    }
+
+    let i = 0
+    do {
+      const a = this.build[i]
+      const b = other.build[i]
+      debug('build compare', i, a, b)
+      if (a === undefined && b === undefined) {
+        return 0
+      } else if (b === undefined) {
+        return 1
+      } else if (a === undefined) {
+        return -1
+      } else if (a === b) {
+        continue
+      } else {
+        return compareIdentifiers(a, b)
+      }
+    } while (++i)
+  }
+
+  // preminor will bump the version up to the next minor release, and immediately
+  // down to pre-release. premajor and prepatch work the same way.
+  inc (release, identifier, identifierBase) {
+    if (release.startsWith('pre')) {
+      if (!identifier && identifierBase === false) {
+        throw new Error('invalid increment argument: identifier is empty')
+      }
+      // Avoid an invalid semver results
+      if (identifier) {
+        const match = `-${identifier}`.match(this.options.loose ? re[t.PRERELEASELOOSE] : re[t.PRERELEASE])
+        if (!match || match[1] !== identifier) {
+          throw new Error(`invalid identifier: ${identifier}`)
+        }
+      }
+    }
+
+    switch (release) {
+      case 'premajor':
+        this.prerelease.length = 0
+        this.patch = 0
+        this.minor = 0
+        this.major++
+        this.inc('pre', identifier, identifierBase)
+        break
+      case 'preminor':
+        this.prerelease.length = 0
+        this.patch = 0
+        this.minor++
+        this.inc('pre', identifier, identifierBase)
+        break
+      case 'prepatch':
+        // If this is already a prerelease, it will bump to the next version
+        // drop any prereleases that might already exist, since they are not
+        // relevant at this point.
+        this.prerelease.length = 0
+        this.inc('patch', identifier, identifierBase)
+        this.inc('pre', identifier, identifierBase)
+        break
+      // If the input is a non-prerelease version, this acts the same as
+      // prepatch.
+      case 'prerelease':
+        if (this.prerelease.length === 0) {
+          this.inc('patch', identifier, identifierBase)
+        }
+        this.inc('pre', identifier, identifierBase)
+        break
+      case 'release':
+        if (this.prerelease.length === 0) {
+          throw new Error(`version ${this.raw} is not a prerelease`)
+        }
+        this.prerelease.length = 0
+        break
+
+      case 'major':
+        // If this is a pre-major version, bump up to the same major version.
+        // Otherwise increment major.
+        // 1.0.0-5 bumps to 1.0.0
+        // 1.1.0 bumps to 2.0.0
+        if (
+          this.minor !== 0 ||
+          this.patch !== 0 ||
+          this.prerelease.length === 0
+        ) {
+          this.major++
+        }
+        this.minor = 0
+        this.patch = 0
+        this.prerelease = []
+        break
+      case 'minor':
+        // If this is a pre-minor version, bump up to the same minor version.
+        // Otherwise increment minor.
+        // 1.2.0-5 bumps to 1.2.0
+        // 1.2.1 bumps to 1.3.0
+        if (this.patch !== 0 || this.prerelease.length === 0) {
+          this.minor++
+        }
+        this.patch = 0
+        this.prerelease = []
+        break
+      case 'patch':
+        // If this is not a pre-release version, it will increment the patch.
+        // If it is a pre-release it will bump up to the same patch version.
+        // 1.2.0-5 patches to 1.2.0
+        // 1.2.0 patches to 1.2.1
+        if (this.prerelease.length === 0) {
+          this.patch++
+        }
+        this.prerelease = []
+        break
+      // This probably shouldn't be used publicly.
+      // 1.0.0 'pre' would become 1.0.0-0 which is the wrong direction.
+      case 'pre': {
+        const base = Number(identifierBase) ? 1 : 0
+
+        if (this.prerelease.length === 0) {
+          this.prerelease = [base]
+        } else {
+          let i = this.prerelease.length
+          while (--i >= 0) {
+            if (typeof this.prerelease[i] === 'number') {
+              this.prerelease[i]++
+              i = -2
+            }
+          }
+          if (i === -1) {
+            // didn't increment anything
+            if (identifier === this.prerelease.join('.') && identifierBase === false) {
+              throw new Error('invalid increment argument: identifier already exists')
+            }
+            this.prerelease.push(base)
+          }
+        }
+        if (identifier) {
+          // 1.2.0-beta.1 bumps to 1.2.0-beta.2,
+          // 1.2.0-beta.fooblz or 1.2.0-beta bumps to 1.2.0-beta.0
+          let prerelease = [identifier, base]
+          if (identifierBase === false) {
+            prerelease = [identifier]
+          }
+          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
+            if (isNaN(this.prerelease[1])) {
+              this.prerelease = prerelease
+            }
+          } else {
+            this.prerelease = prerelease
+          }
+        }
+        break
+      }
+      default:
+        throw new Error(`invalid increment argument: ${release}`)
+    }
+    this.raw = this.format()
+    if (this.build.length) {
+      this.raw += `+${this.build.join('.')}`
+    }
+    return this
+  }
+}
+
+module.exports = SemVer
+
+
+/***/ }),
+
+/***/ 7701:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const parse = __nccwpck_require__(2822)
+const clean = (version, options) => {
+  const s = parse(version.trim().replace(/^[=v]+/, ''), options)
+  return s ? s.version : null
+}
+module.exports = clean
+
+
+/***/ }),
+
+/***/ 3210:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const eq = __nccwpck_require__(7718)
+const neq = __nccwpck_require__(2048)
+const gt = __nccwpck_require__(4211)
+const gte = __nccwpck_require__(9939)
+const lt = __nccwpck_require__(6017)
+const lte = __nccwpck_require__(8098)
+
+const cmp = (a, op, b, loose) => {
+  switch (op) {
+    case '===':
+      if (typeof a === 'object') {
+        a = a.version
+      }
+      if (typeof b === 'object') {
+        b = b.version
+      }
+      return a === b
+
+    case '!==':
+      if (typeof a === 'object') {
+        a = a.version
+      }
+      if (typeof b === 'object') {
+        b = b.version
+      }
+      return a !== b
+
+    case '':
+    case '=':
+    case '==':
+      return eq(a, b, loose)
+
+    case '!=':
+      return neq(a, b, loose)
+
+    case '>':
+      return gt(a, b, loose)
+
+    case '>=':
+      return gte(a, b, loose)
+
+    case '<':
+      return lt(a, b, loose)
+
+    case '<=':
+      return lte(a, b, loose)
+
+    default:
+      throw new TypeError(`Invalid operator: ${op}`)
+  }
+}
+module.exports = cmp
+
+
+/***/ }),
+
+/***/ 4232:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const parse = __nccwpck_require__(2822)
+const { safeRe: re, t } = __nccwpck_require__(6154)
+
+const coerce = (version, options) => {
+  if (version instanceof SemVer) {
+    return version
+  }
+
+  if (typeof version === 'number') {
+    version = String(version)
+  }
+
+  if (typeof version !== 'string') {
+    return null
+  }
+
+  options = options || {}
+
+  let match = null
+  if (!options.rtl) {
+    match = version.match(options.includePrerelease ? re[t.COERCEFULL] : re[t.COERCE])
+  } else {
+    // Find the right-most coercible string that does not share
+    // a terminus with a more left-ward coercible string.
+    // Eg, '1.2.3.4' wants to coerce '2.3.4', not '3.4' or '4'
+    // With includePrerelease option set, '1.2.3.4-rc' wants to coerce '2.3.4-rc', not '2.3.4'
+    //
+    // Walk through the string checking with a /g regexp
+    // Manually set the index so as to pick up overlapping matches.
+    // Stop when we get a match that ends at the string end, since no
+    // coercible string can be more right-ward without the same terminus.
+    const coerceRtlRegex = options.includePrerelease ? re[t.COERCERTLFULL] : re[t.COERCERTL]
+    let next
+    while ((next = coerceRtlRegex.exec(version)) &&
+        (!match || match.index + match[0].length !== version.length)
+    ) {
+      if (!match ||
+            next.index + next[0].length !== match.index + match[0].length) {
+        match = next
+      }
+      coerceRtlRegex.lastIndex = next.index + next[1].length + next[2].length
+    }
+    // leave it in a clean state
+    coerceRtlRegex.lastIndex = -1
+  }
+
+  if (match === null) {
+    return null
+  }
+
+  const major = match[2]
+  const minor = match[3] || '0'
+  const patch = match[4] || '0'
+  const prerelease = options.includePrerelease && match[5] ? `-${match[5]}` : ''
+  const build = options.includePrerelease && match[6] ? `+${match[6]}` : ''
+
+  return parse(`${major}.${minor}.${patch}${prerelease}${build}`, options)
+}
+module.exports = coerce
+
+
+/***/ }),
+
+/***/ 552:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const compareBuild = (a, b, loose) => {
+  const versionA = new SemVer(a, loose)
+  const versionB = new SemVer(b, loose)
+  return versionA.compare(versionB) || versionA.compareBuild(versionB)
+}
+module.exports = compareBuild
+
+
+/***/ }),
+
+/***/ 1331:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const compareLoose = (a, b) => compare(a, b, true)
+module.exports = compareLoose
+
+
+/***/ }),
+
+/***/ 2826:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const compare = (a, b, loose) =>
+  new SemVer(a, loose).compare(new SemVer(b, loose))
+
+module.exports = compare
+
+
+/***/ }),
+
+/***/ 1842:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const parse = __nccwpck_require__(2822)
+
+const diff = (version1, version2) => {
+  const v1 = parse(version1, null, true)
+  const v2 = parse(version2, null, true)
+  const comparison = v1.compare(v2)
+
+  if (comparison === 0) {
+    return null
+  }
+
+  const v1Higher = comparison > 0
+  const highVersion = v1Higher ? v1 : v2
+  const lowVersion = v1Higher ? v2 : v1
+  const highHasPre = !!highVersion.prerelease.length
+  const lowHasPre = !!lowVersion.prerelease.length
+
+  if (lowHasPre && !highHasPre) {
+    // Going from prerelease -> no prerelease requires some special casing
+
+    // If the low version has only a major, then it will always be a major
+    // Some examples:
+    // 1.0.0-1 -> 1.0.0
+    // 1.0.0-1 -> 1.1.1
+    // 1.0.0-1 -> 2.0.0
+    if (!lowVersion.patch && !lowVersion.minor) {
+      return 'major'
+    }
+
+    // If the main part has no difference
+    if (lowVersion.compareMain(highVersion) === 0) {
+      if (lowVersion.minor && !lowVersion.patch) {
+        return 'minor'
+      }
+      return 'patch'
+    }
+  }
+
+  // add the `pre` prefix if we are going to a prerelease version
+  const prefix = highHasPre ? 'pre' : ''
+
+  if (v1.major !== v2.major) {
+    return prefix + 'major'
+  }
+
+  if (v1.minor !== v2.minor) {
+    return prefix + 'minor'
+  }
+
+  if (v1.patch !== v2.patch) {
+    return prefix + 'patch'
+  }
+
+  // high and low are preleases
+  return 'prerelease'
+}
+
+module.exports = diff
+
+
+/***/ }),
+
+/***/ 7718:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const eq = (a, b, loose) => compare(a, b, loose) === 0
+module.exports = eq
+
+
+/***/ }),
+
+/***/ 4211:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const gt = (a, b, loose) => compare(a, b, loose) > 0
+module.exports = gt
+
+
+/***/ }),
+
+/***/ 9939:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const gte = (a, b, loose) => compare(a, b, loose) >= 0
+module.exports = gte
+
+
+/***/ }),
+
+/***/ 7489:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+
+const inc = (version, release, options, identifier, identifierBase) => {
+  if (typeof (options) === 'string') {
+    identifierBase = identifier
+    identifier = options
+    options = undefined
+  }
+
+  try {
+    return new SemVer(
+      version instanceof SemVer ? version.version : version,
+      options
+    ).inc(release, identifier, identifierBase).version
+  } catch (er) {
+    return null
+  }
+}
+module.exports = inc
+
+
+/***/ }),
+
+/***/ 6017:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const lt = (a, b, loose) => compare(a, b, loose) < 0
+module.exports = lt
+
+
+/***/ }),
+
+/***/ 8098:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const lte = (a, b, loose) => compare(a, b, loose) <= 0
+module.exports = lte
+
+
+/***/ }),
+
+/***/ 2529:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const major = (a, loose) => new SemVer(a, loose).major
+module.exports = major
+
+
+/***/ }),
+
+/***/ 4313:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const minor = (a, loose) => new SemVer(a, loose).minor
+module.exports = minor
+
+
+/***/ }),
+
+/***/ 2048:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const neq = (a, b, loose) => compare(a, b, loose) !== 0
+module.exports = neq
+
+
+/***/ }),
+
+/***/ 2822:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const parse = (version, options, throwErrors = false) => {
+  if (version instanceof SemVer) {
+    return version
+  }
+  try {
+    return new SemVer(version, options)
+  } catch (er) {
+    if (!throwErrors) {
+      return null
+    }
+    throw er
+  }
+}
+
+module.exports = parse
+
+
+/***/ }),
+
+/***/ 5457:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const patch = (a, loose) => new SemVer(a, loose).patch
+module.exports = patch
+
+
+/***/ }),
+
+/***/ 1235:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const parse = __nccwpck_require__(2822)
+const prerelease = (version, options) => {
+  const parsed = parse(version, options)
+  return (parsed && parsed.prerelease.length) ? parsed.prerelease : null
+}
+module.exports = prerelease
+
+
+/***/ }),
+
+/***/ 4431:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compare = __nccwpck_require__(2826)
+const rcompare = (a, b, loose) => compare(b, a, loose)
+module.exports = rcompare
+
+
+/***/ }),
+
+/***/ 2107:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compareBuild = __nccwpck_require__(552)
+const rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose))
+module.exports = rsort
+
+
+/***/ }),
+
+/***/ 8991:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const Range = __nccwpck_require__(4506)
+const satisfies = (version, range, options) => {
+  try {
+    range = new Range(range, options)
+  } catch (er) {
+    return false
+  }
+  return range.test(version)
+}
+module.exports = satisfies
+
+
+/***/ }),
+
+/***/ 3395:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const compareBuild = __nccwpck_require__(552)
+const sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose))
+module.exports = sort
+
+
+/***/ }),
+
+/***/ 3357:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const parse = __nccwpck_require__(2822)
+const valid = (version, options) => {
+  const v = parse(version, options)
+  return v ? v.version : null
+}
+module.exports = valid
+
+
+/***/ }),
+
+/***/ 4038:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+// just pre-load all the stuff that index.js lazily exports
+const internalRe = __nccwpck_require__(6154)
+const constants = __nccwpck_require__(3285)
+const SemVer = __nccwpck_require__(2614)
+const identifiers = __nccwpck_require__(8983)
+const parse = __nccwpck_require__(2822)
+const valid = __nccwpck_require__(3357)
+const clean = __nccwpck_require__(7701)
+const inc = __nccwpck_require__(7489)
+const diff = __nccwpck_require__(1842)
+const major = __nccwpck_require__(2529)
+const minor = __nccwpck_require__(4313)
+const patch = __nccwpck_require__(5457)
+const prerelease = __nccwpck_require__(1235)
+const compare = __nccwpck_require__(2826)
+const rcompare = __nccwpck_require__(4431)
+const compareLoose = __nccwpck_require__(1331)
+const compareBuild = __nccwpck_require__(552)
+const sort = __nccwpck_require__(3395)
+const rsort = __nccwpck_require__(2107)
+const gt = __nccwpck_require__(4211)
+const lt = __nccwpck_require__(6017)
+const eq = __nccwpck_require__(7718)
+const neq = __nccwpck_require__(2048)
+const gte = __nccwpck_require__(9939)
+const lte = __nccwpck_require__(8098)
+const cmp = __nccwpck_require__(3210)
+const coerce = __nccwpck_require__(4232)
+const Comparator = __nccwpck_require__(8106)
+const Range = __nccwpck_require__(4506)
+const satisfies = __nccwpck_require__(8991)
+const toComparators = __nccwpck_require__(4203)
+const maxSatisfying = __nccwpck_require__(9597)
+const minSatisfying = __nccwpck_require__(7749)
+const minVersion = __nccwpck_require__(5663)
+const validRange = __nccwpck_require__(1314)
+const outside = __nccwpck_require__(6217)
+const gtr = __nccwpck_require__(4204)
+const ltr = __nccwpck_require__(1427)
+const intersects = __nccwpck_require__(2658)
+const simplifyRange = __nccwpck_require__(5085)
+const subset = __nccwpck_require__(5126)
+module.exports = {
+  parse,
+  valid,
+  clean,
+  inc,
+  diff,
+  major,
+  minor,
+  patch,
+  prerelease,
+  compare,
+  rcompare,
+  compareLoose,
+  compareBuild,
+  sort,
+  rsort,
+  gt,
+  lt,
+  eq,
+  neq,
+  gte,
+  lte,
+  cmp,
+  coerce,
+  Comparator,
+  Range,
+  satisfies,
+  toComparators,
+  maxSatisfying,
+  minSatisfying,
+  minVersion,
+  validRange,
+  outside,
+  gtr,
+  ltr,
+  intersects,
+  simplifyRange,
+  subset,
+  SemVer,
+  re: internalRe.re,
+  src: internalRe.src,
+  tokens: internalRe.t,
+  SEMVER_SPEC_VERSION: constants.SEMVER_SPEC_VERSION,
+  RELEASE_TYPES: constants.RELEASE_TYPES,
+  compareIdentifiers: identifiers.compareIdentifiers,
+  rcompareIdentifiers: identifiers.rcompareIdentifiers,
+}
+
+
+/***/ }),
+
+/***/ 3285:
+/***/ ((module) => {
+
+"use strict";
+
+
+// Note: this is the semver.org version of the spec that it implements
+// Not necessarily the package version of this code.
+const SEMVER_SPEC_VERSION = '2.0.0'
+
+const MAX_LENGTH = 256
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||
+/* istanbul ignore next */ 9007199254740991
+
+// Max safe segment length for coercion.
+const MAX_SAFE_COMPONENT_LENGTH = 16
+
+// Max safe length for a build identifier. The max length minus 6 characters for
+// the shortest version with a build 0.0.0+BUILD.
+const MAX_SAFE_BUILD_LENGTH = MAX_LENGTH - 6
+
+const RELEASE_TYPES = [
+  'major',
+  'premajor',
+  'minor',
+  'preminor',
+  'patch',
+  'prepatch',
+  'prerelease',
+]
+
+module.exports = {
+  MAX_LENGTH,
+  MAX_SAFE_COMPONENT_LENGTH,
+  MAX_SAFE_BUILD_LENGTH,
+  MAX_SAFE_INTEGER,
+  RELEASE_TYPES,
+  SEMVER_SPEC_VERSION,
+  FLAG_INCLUDE_PRERELEASE: 0b001,
+  FLAG_LOOSE: 0b010,
+}
+
+
+/***/ }),
+
+/***/ 1858:
+/***/ ((module) => {
+
+"use strict";
+
+
+const debug = (
+  typeof process === 'object' &&
+  process.env &&
+  process.env.NODE_DEBUG &&
+  /\bsemver\b/i.test(process.env.NODE_DEBUG)
+) ? (...args) => console.error('SEMVER', ...args)
+  : () => {}
+
+module.exports = debug
+
+
+/***/ }),
+
+/***/ 8983:
+/***/ ((module) => {
+
+"use strict";
+
+
+const numeric = /^[0-9]+$/
+const compareIdentifiers = (a, b) => {
+  const anum = numeric.test(a)
+  const bnum = numeric.test(b)
+
+  if (anum && bnum) {
+    a = +a
+    b = +b
+  }
+
+  return a === b ? 0
+    : (anum && !bnum) ? -1
+    : (bnum && !anum) ? 1
+    : a < b ? -1
+    : 1
+}
+
+const rcompareIdentifiers = (a, b) => compareIdentifiers(b, a)
+
+module.exports = {
+  compareIdentifiers,
+  rcompareIdentifiers,
+}
+
+
+/***/ }),
+
+/***/ 520:
+/***/ ((module) => {
+
+"use strict";
+
+
+class LRUCache {
+  constructor () {
+    this.max = 1000
+    this.map = new Map()
+  }
+
+  get (key) {
+    const value = this.map.get(key)
+    if (value === undefined) {
+      return undefined
+    } else {
+      // Remove the key from the map and add it to the end
+      this.map.delete(key)
+      this.map.set(key, value)
+      return value
+    }
+  }
+
+  delete (key) {
+    return this.map.delete(key)
+  }
+
+  set (key, value) {
+    const deleted = this.delete(key)
+
+    if (!deleted && value !== undefined) {
+      // If cache is full, delete the least recently used item
+      if (this.map.size >= this.max) {
+        const firstKey = this.map.keys().next().value
+        this.delete(firstKey)
+      }
+
+      this.map.set(key, value)
+    }
+
+    return this
+  }
+}
+
+module.exports = LRUCache
+
+
+/***/ }),
+
+/***/ 7371:
+/***/ ((module) => {
+
+"use strict";
+
+
+// parse out just the options we care about
+const looseOption = Object.freeze({ loose: true })
+const emptyOpts = Object.freeze({ })
+const parseOptions = options => {
+  if (!options) {
+    return emptyOpts
+  }
+
+  if (typeof options !== 'object') {
+    return looseOption
+  }
+
+  return options
+}
+module.exports = parseOptions
+
+
+/***/ }),
+
+/***/ 6154:
+/***/ ((module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const {
+  MAX_SAFE_COMPONENT_LENGTH,
+  MAX_SAFE_BUILD_LENGTH,
+  MAX_LENGTH,
+} = __nccwpck_require__(3285)
+const debug = __nccwpck_require__(1858)
+exports = module.exports = {}
+
+// The actual regexps go on exports.re
+const re = exports.re = []
+const safeRe = exports.safeRe = []
+const src = exports.src = []
+const safeSrc = exports.safeSrc = []
+const t = exports.t = {}
+let R = 0
+
+const LETTERDASHNUMBER = '[a-zA-Z0-9-]'
+
+// Replace some greedy regex tokens to prevent regex dos issues. These regex are
+// used internally via the safeRe object since all inputs in this library get
+// normalized first to trim and collapse all extra whitespace. The original
+// regexes are exported for userland consumption and lower level usage. A
+// future breaking change could export the safer regex only with a note that
+// all input should have extra whitespace removed.
+const safeRegexReplacements = [
+  ['\\s', 1],
+  ['\\d', MAX_LENGTH],
+  [LETTERDASHNUMBER, MAX_SAFE_BUILD_LENGTH],
+]
+
+const makeSafeRegex = (value) => {
+  for (const [token, max] of safeRegexReplacements) {
+    value = value
+      .split(`${token}*`).join(`${token}{0,${max}}`)
+      .split(`${token}+`).join(`${token}{1,${max}}`)
+  }
+  return value
+}
+
+const createToken = (name, value, isGlobal) => {
+  const safe = makeSafeRegex(value)
+  const index = R++
+  debug(name, index, value)
+  t[name] = index
+  src[index] = value
+  safeSrc[index] = safe
+  re[index] = new RegExp(value, isGlobal ? 'g' : undefined)
+  safeRe[index] = new RegExp(safe, isGlobal ? 'g' : undefined)
+}
+
+// The following Regular Expressions can be used for tokenizing,
+// validating, and parsing SemVer version strings.
+
+// ## Numeric Identifier
+// A single `0`, or a non-zero digit followed by zero or more digits.
+
+createToken('NUMERICIDENTIFIER', '0|[1-9]\\d*')
+createToken('NUMERICIDENTIFIERLOOSE', '\\d+')
+
+// ## Non-numeric Identifier
+// Zero or more digits, followed by a letter or hyphen, and then zero or
+// more letters, digits, or hyphens.
+
+createToken('NONNUMERICIDENTIFIER', `\\d*[a-zA-Z-]${LETTERDASHNUMBER}*`)
+
+// ## Main Version
+// Three dot-separated numeric identifiers.
+
+createToken('MAINVERSION', `(${src[t.NUMERICIDENTIFIER]})\\.` +
+                   `(${src[t.NUMERICIDENTIFIER]})\\.` +
+                   `(${src[t.NUMERICIDENTIFIER]})`)
+
+createToken('MAINVERSIONLOOSE', `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.` +
+                        `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.` +
+                        `(${src[t.NUMERICIDENTIFIERLOOSE]})`)
+
+// ## Pre-release Version Identifier
+// A numeric identifier, or a non-numeric identifier.
+// Non-numberic identifiers include numberic identifiers but can be longer.
+// Therefore non-numberic identifiers must go first.
+
+createToken('PRERELEASEIDENTIFIER', `(?:${src[t.NONNUMERICIDENTIFIER]
+}|${src[t.NUMERICIDENTIFIER]})`)
+
+createToken('PRERELEASEIDENTIFIERLOOSE', `(?:${src[t.NONNUMERICIDENTIFIER]
+}|${src[t.NUMERICIDENTIFIERLOOSE]})`)
+
+// ## Pre-release Version
+// Hyphen, followed by one or more dot-separated pre-release version
+// identifiers.
+
+createToken('PRERELEASE', `(?:-(${src[t.PRERELEASEIDENTIFIER]
+}(?:\\.${src[t.PRERELEASEIDENTIFIER]})*))`)
+
+createToken('PRERELEASELOOSE', `(?:-?(${src[t.PRERELEASEIDENTIFIERLOOSE]
+}(?:\\.${src[t.PRERELEASEIDENTIFIERLOOSE]})*))`)
+
+// ## Build Metadata Identifier
+// Any combination of digits, letters, or hyphens.
+
+createToken('BUILDIDENTIFIER', `${LETTERDASHNUMBER}+`)
+
+// ## Build Metadata
+// Plus sign, followed by one or more period-separated build metadata
+// identifiers.
+
+createToken('BUILD', `(?:\\+(${src[t.BUILDIDENTIFIER]
+}(?:\\.${src[t.BUILDIDENTIFIER]})*))`)
+
+// ## Full Version String
+// A main version, followed optionally by a pre-release version and
+// build metadata.
+
+// Note that the only major, minor, patch, and pre-release sections of
+// the version string are capturing groups.  The build metadata is not a
+// capturing group, because it should not ever be used in version
+// comparison.
+
+createToken('FULLPLAIN', `v?${src[t.MAINVERSION]
+}${src[t.PRERELEASE]}?${
+  src[t.BUILD]}?`)
+
+createToken('FULL', `^${src[t.FULLPLAIN]}$`)
+
+// like full, but allows v1.2.3 and =1.2.3, which people do sometimes.
+// also, 1.0.0alpha1 (prerelease without the hyphen) which is pretty
+// common in the npm registry.
+createToken('LOOSEPLAIN', `[v=\\s]*${src[t.MAINVERSIONLOOSE]
+}${src[t.PRERELEASELOOSE]}?${
+  src[t.BUILD]}?`)
+
+createToken('LOOSE', `^${src[t.LOOSEPLAIN]}$`)
+
+createToken('GTLT', '((?:<|>)?=?)')
+
+// Something like "2.*" or "1.2.x".
+// Note that "x.x" is a valid xRange identifer, meaning "any version"
+// Only the first item is strictly required.
+createToken('XRANGEIDENTIFIERLOOSE', `${src[t.NUMERICIDENTIFIERLOOSE]}|x|X|\\*`)
+createToken('XRANGEIDENTIFIER', `${src[t.NUMERICIDENTIFIER]}|x|X|\\*`)
+
+createToken('XRANGEPLAIN', `[v=\\s]*(${src[t.XRANGEIDENTIFIER]})` +
+                   `(?:\\.(${src[t.XRANGEIDENTIFIER]})` +
+                   `(?:\\.(${src[t.XRANGEIDENTIFIER]})` +
+                   `(?:${src[t.PRERELEASE]})?${
+                     src[t.BUILD]}?` +
+                   `)?)?`)
+
+createToken('XRANGEPLAINLOOSE', `[v=\\s]*(${src[t.XRANGEIDENTIFIERLOOSE]})` +
+                        `(?:\\.(${src[t.XRANGEIDENTIFIERLOOSE]})` +
+                        `(?:\\.(${src[t.XRANGEIDENTIFIERLOOSE]})` +
+                        `(?:${src[t.PRERELEASELOOSE]})?${
+                          src[t.BUILD]}?` +
+                        `)?)?`)
+
+createToken('XRANGE', `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAIN]}$`)
+createToken('XRANGELOOSE', `^${src[t.GTLT]}\\s*${src[t.XRANGEPLAINLOOSE]}$`)
+
+// Coercion.
+// Extract anything that could conceivably be a part of a valid semver
+createToken('COERCEPLAIN', `${'(^|[^\\d])' +
+              '(\\d{1,'}${MAX_SAFE_COMPONENT_LENGTH}})` +
+              `(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}}))?` +
+              `(?:\\.(\\d{1,${MAX_SAFE_COMPONENT_LENGTH}}))?`)
+createToken('COERCE', `${src[t.COERCEPLAIN]}(?:$|[^\\d])`)
+createToken('COERCEFULL', src[t.COERCEPLAIN] +
+              `(?:${src[t.PRERELEASE]})?` +
+              `(?:${src[t.BUILD]})?` +
+              `(?:$|[^\\d])`)
+createToken('COERCERTL', src[t.COERCE], true)
+createToken('COERCERTLFULL', src[t.COERCEFULL], true)
+
+// Tilde ranges.
+// Meaning is "reasonably at or greater than"
+createToken('LONETILDE', '(?:~>?)')
+
+createToken('TILDETRIM', `(\\s*)${src[t.LONETILDE]}\\s+`, true)
+exports.tildeTrimReplace = '$1~'
+
+createToken('TILDE', `^${src[t.LONETILDE]}${src[t.XRANGEPLAIN]}$`)
+createToken('TILDELOOSE', `^${src[t.LONETILDE]}${src[t.XRANGEPLAINLOOSE]}$`)
+
+// Caret ranges.
+// Meaning is "at least and backwards compatible with"
+createToken('LONECARET', '(?:\\^)')
+
+createToken('CARETTRIM', `(\\s*)${src[t.LONECARET]}\\s+`, true)
+exports.caretTrimReplace = '$1^'
+
+createToken('CARET', `^${src[t.LONECARET]}${src[t.XRANGEPLAIN]}$`)
+createToken('CARETLOOSE', `^${src[t.LONECARET]}${src[t.XRANGEPLAINLOOSE]}$`)
+
+// A simple gt/lt/eq thing, or just "" to indicate "any version"
+createToken('COMPARATORLOOSE', `^${src[t.GTLT]}\\s*(${src[t.LOOSEPLAIN]})$|^$`)
+createToken('COMPARATOR', `^${src[t.GTLT]}\\s*(${src[t.FULLPLAIN]})$|^$`)
+
+// An expression to strip any whitespace between the gtlt and the thing
+// it modifies, so that `> 1.2.3` ==> `>1.2.3`
+createToken('COMPARATORTRIM', `(\\s*)${src[t.GTLT]
+}\\s*(${src[t.LOOSEPLAIN]}|${src[t.XRANGEPLAIN]})`, true)
+exports.comparatorTrimReplace = '$1$2$3'
+
+// Something like `1.2.3 - 1.2.4`
+// Note that these all use the loose form, because they'll be
+// checked against either the strict or loose comparator form
+// later.
+createToken('HYPHENRANGE', `^\\s*(${src[t.XRANGEPLAIN]})` +
+                   `\\s+-\\s+` +
+                   `(${src[t.XRANGEPLAIN]})` +
+                   `\\s*$`)
+
+createToken('HYPHENRANGELOOSE', `^\\s*(${src[t.XRANGEPLAINLOOSE]})` +
+                        `\\s+-\\s+` +
+                        `(${src[t.XRANGEPLAINLOOSE]})` +
+                        `\\s*$`)
+
+// Star ranges basically just allow anything at all.
+createToken('STAR', '(<|>)?=?\\s*\\*')
+// >=0.0.0 is like a star
+createToken('GTE0', '^\\s*>=\\s*0\\.0\\.0\\s*$')
+createToken('GTE0PRE', '^\\s*>=\\s*0\\.0\\.0-0\\s*$')
+
+
+/***/ }),
+
+/***/ 4204:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+// Determine if version is greater than all the versions possible in the range.
+const outside = __nccwpck_require__(6217)
+const gtr = (version, range, options) => outside(version, range, '>', options)
+module.exports = gtr
+
+
+/***/ }),
+
+/***/ 2658:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const Range = __nccwpck_require__(4506)
+const intersects = (r1, r2, options) => {
+  r1 = new Range(r1, options)
+  r2 = new Range(r2, options)
+  return r1.intersects(r2, options)
+}
+module.exports = intersects
+
+
+/***/ }),
+
+/***/ 1427:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const outside = __nccwpck_require__(6217)
+// Determine if version is less than all the versions possible in the range
+const ltr = (version, range, options) => outside(version, range, '<', options)
+module.exports = ltr
+
+
+/***/ }),
+
+/***/ 9597:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const Range = __nccwpck_require__(4506)
+
+const maxSatisfying = (versions, range, options) => {
+  let max = null
+  let maxSV = null
+  let rangeObj = null
+  try {
+    rangeObj = new Range(range, options)
+  } catch (er) {
+    return null
+  }
+  versions.forEach((v) => {
+    if (rangeObj.test(v)) {
+      // satisfies(v, range, options)
+      if (!max || maxSV.compare(v) === -1) {
+        // compare(max, v, true)
+        max = v
+        maxSV = new SemVer(max, options)
+      }
+    }
+  })
+  return max
+}
+module.exports = maxSatisfying
+
+
+/***/ }),
+
+/***/ 7749:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const Range = __nccwpck_require__(4506)
+const minSatisfying = (versions, range, options) => {
+  let min = null
+  let minSV = null
+  let rangeObj = null
+  try {
+    rangeObj = new Range(range, options)
+  } catch (er) {
+    return null
+  }
+  versions.forEach((v) => {
+    if (rangeObj.test(v)) {
+      // satisfies(v, range, options)
+      if (!min || minSV.compare(v) === 1) {
+        // compare(min, v, true)
+        min = v
+        minSV = new SemVer(min, options)
+      }
+    }
+  })
+  return min
+}
+module.exports = minSatisfying
+
+
+/***/ }),
+
+/***/ 5663:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const Range = __nccwpck_require__(4506)
+const gt = __nccwpck_require__(4211)
+
+const minVersion = (range, loose) => {
+  range = new Range(range, loose)
+
+  let minver = new SemVer('0.0.0')
+  if (range.test(minver)) {
+    return minver
+  }
+
+  minver = new SemVer('0.0.0-0')
+  if (range.test(minver)) {
+    return minver
+  }
+
+  minver = null
+  for (let i = 0; i < range.set.length; ++i) {
+    const comparators = range.set[i]
+
+    let setMin = null
+    comparators.forEach((comparator) => {
+      // Clone to avoid manipulating the comparator's semver object.
+      const compver = new SemVer(comparator.semver.version)
+      switch (comparator.operator) {
+        case '>':
+          if (compver.prerelease.length === 0) {
+            compver.patch++
+          } else {
+            compver.prerelease.push(0)
+          }
+          compver.raw = compver.format()
+          /* fallthrough */
+        case '':
+        case '>=':
+          if (!setMin || gt(compver, setMin)) {
+            setMin = compver
+          }
+          break
+        case '<':
+        case '<=':
+          /* Ignore maximum versions */
+          break
+        /* istanbul ignore next */
+        default:
+          throw new Error(`Unexpected operation: ${comparator.operator}`)
+      }
+    })
+    if (setMin && (!minver || gt(minver, setMin))) {
+      minver = setMin
+    }
+  }
+
+  if (minver && range.test(minver)) {
+    return minver
+  }
+
+  return null
+}
+module.exports = minVersion
+
+
+/***/ }),
+
+/***/ 6217:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const SemVer = __nccwpck_require__(2614)
+const Comparator = __nccwpck_require__(8106)
+const { ANY } = Comparator
+const Range = __nccwpck_require__(4506)
+const satisfies = __nccwpck_require__(8991)
+const gt = __nccwpck_require__(4211)
+const lt = __nccwpck_require__(6017)
+const lte = __nccwpck_require__(8098)
+const gte = __nccwpck_require__(9939)
+
+const outside = (version, range, hilo, options) => {
+  version = new SemVer(version, options)
+  range = new Range(range, options)
+
+  let gtfn, ltefn, ltfn, comp, ecomp
+  switch (hilo) {
+    case '>':
+      gtfn = gt
+      ltefn = lte
+      ltfn = lt
+      comp = '>'
+      ecomp = '>='
+      break
+    case '<':
+      gtfn = lt
+      ltefn = gte
+      ltfn = gt
+      comp = '<'
+      ecomp = '<='
+      break
+    default:
+      throw new TypeError('Must provide a hilo val of "<" or ">"')
+  }
+
+  // If it satisfies the range it is not outside
+  if (satisfies(version, range, options)) {
+    return false
+  }
+
+  // From now on, variable terms are as if we're in "gtr" mode.
+  // but note that everything is flipped for the "ltr" function.
+
+  for (let i = 0; i < range.set.length; ++i) {
+    const comparators = range.set[i]
+
+    let high = null
+    let low = null
+
+    comparators.forEach((comparator) => {
+      if (comparator.semver === ANY) {
+        comparator = new Comparator('>=0.0.0')
+      }
+      high = high || comparator
+      low = low || comparator
+      if (gtfn(comparator.semver, high.semver, options)) {
+        high = comparator
+      } else if (ltfn(comparator.semver, low.semver, options)) {
+        low = comparator
+      }
+    })
+
+    // If the edge version comparator has a operator then our version
+    // isn't outside it
+    if (high.operator === comp || high.operator === ecomp) {
+      return false
+    }
+
+    // If the lowest version comparator has an operator and our version
+    // is less than it then it isn't higher than the range
+    if ((!low.operator || low.operator === comp) &&
+        ltefn(version, low.semver)) {
+      return false
+    } else if (low.operator === ecomp && ltfn(version, low.semver)) {
+      return false
+    }
+  }
+  return true
+}
+
+module.exports = outside
+
+
+/***/ }),
+
+/***/ 5085:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+// given a set of versions and a range, create a "simplified" range
+// that includes the same versions that the original range does
+// If the original range is shorter than the simplified one, return that.
+const satisfies = __nccwpck_require__(8991)
+const compare = __nccwpck_require__(2826)
+module.exports = (versions, range, options) => {
+  const set = []
+  let first = null
+  let prev = null
+  const v = versions.sort((a, b) => compare(a, b, options))
+  for (const version of v) {
+    const included = satisfies(version, range, options)
+    if (included) {
+      prev = version
+      if (!first) {
+        first = version
+      }
+    } else {
+      if (prev) {
+        set.push([first, prev])
+      }
+      prev = null
+      first = null
+    }
+  }
+  if (first) {
+    set.push([first, null])
+  }
+
+  const ranges = []
+  for (const [min, max] of set) {
+    if (min === max) {
+      ranges.push(min)
+    } else if (!max && min === v[0]) {
+      ranges.push('*')
+    } else if (!max) {
+      ranges.push(`>=${min}`)
+    } else if (min === v[0]) {
+      ranges.push(`<=${max}`)
+    } else {
+      ranges.push(`${min} - ${max}`)
+    }
+  }
+  const simplified = ranges.join(' || ')
+  const original = typeof range.raw === 'string' ? range.raw : String(range)
+  return simplified.length < original.length ? simplified : range
+}
+
+
+/***/ }),
+
+/***/ 5126:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const Range = __nccwpck_require__(4506)
+const Comparator = __nccwpck_require__(8106)
+const { ANY } = Comparator
+const satisfies = __nccwpck_require__(8991)
+const compare = __nccwpck_require__(2826)
+
+// Complex range `r1 || r2 || ...` is a subset of `R1 || R2 || ...` iff:
+// - Every simple range `r1, r2, ...` is a null set, OR
+// - Every simple range `r1, r2, ...` which is not a null set is a subset of
+//   some `R1, R2, ...`
+//
+// Simple range `c1 c2 ...` is a subset of simple range `C1 C2 ...` iff:
+// - If c is only the ANY comparator
+//   - If C is only the ANY comparator, return true
+//   - Else if in prerelease mode, return false
+//   - else replace c with `[>=0.0.0]`
+// - If C is only the ANY comparator
+//   - if in prerelease mode, return true
+//   - else replace C with `[>=0.0.0]`
+// - Let EQ be the set of = comparators in c
+// - If EQ is more than one, return true (null set)
+// - Let GT be the highest > or >= comparator in c
+// - Let LT be the lowest < or <= comparator in c
+// - If GT and LT, and GT.semver > LT.semver, return true (null set)
+// - If any C is a = range, and GT or LT are set, return false
+// - If EQ
+//   - If GT, and EQ does not satisfy GT, return true (null set)
+//   - If LT, and EQ does not satisfy LT, return true (null set)
+//   - If EQ satisfies every C, return true
+//   - Else return false
+// - If GT
+//   - If GT.semver is lower than any > or >= comp in C, return false
+//   - If GT is >=, and GT.semver does not satisfy every C, return false
+//   - If GT.semver has a prerelease, and not in prerelease mode
+//     - If no C has a prerelease and the GT.semver tuple, return false
+// - If LT
+//   - If LT.semver is greater than any < or <= comp in C, return false
+//   - If LT is <=, and LT.semver does not satisfy every C, return false
+//   - If GT.semver has a prerelease, and not in prerelease mode
+//     - If no C has a prerelease and the LT.semver tuple, return false
+// - Else return true
+
+const subset = (sub, dom, options = {}) => {
+  if (sub === dom) {
+    return true
+  }
+
+  sub = new Range(sub, options)
+  dom = new Range(dom, options)
+  let sawNonNull = false
+
+  OUTER: for (const simpleSub of sub.set) {
+    for (const simpleDom of dom.set) {
+      const isSub = simpleSubset(simpleSub, simpleDom, options)
+      sawNonNull = sawNonNull || isSub !== null
+      if (isSub) {
+        continue OUTER
+      }
+    }
+    // the null set is a subset of everything, but null simple ranges in
+    // a complex range should be ignored.  so if we saw a non-null range,
+    // then we know this isn't a subset, but if EVERY simple range was null,
+    // then it is a subset.
+    if (sawNonNull) {
+      return false
+    }
+  }
+  return true
+}
+
+const minimumVersionWithPreRelease = [new Comparator('>=0.0.0-0')]
+const minimumVersion = [new Comparator('>=0.0.0')]
+
+const simpleSubset = (sub, dom, options) => {
+  if (sub === dom) {
+    return true
+  }
+
+  if (sub.length === 1 && sub[0].semver === ANY) {
+    if (dom.length === 1 && dom[0].semver === ANY) {
+      return true
+    } else if (options.includePrerelease) {
+      sub = minimumVersionWithPreRelease
+    } else {
+      sub = minimumVersion
+    }
+  }
+
+  if (dom.length === 1 && dom[0].semver === ANY) {
+    if (options.includePrerelease) {
+      return true
+    } else {
+      dom = minimumVersion
+    }
+  }
+
+  const eqSet = new Set()
+  let gt, lt
+  for (const c of sub) {
+    if (c.operator === '>' || c.operator === '>=') {
+      gt = higherGT(gt, c, options)
+    } else if (c.operator === '<' || c.operator === '<=') {
+      lt = lowerLT(lt, c, options)
+    } else {
+      eqSet.add(c.semver)
+    }
+  }
+
+  if (eqSet.size > 1) {
+    return null
+  }
+
+  let gtltComp
+  if (gt && lt) {
+    gtltComp = compare(gt.semver, lt.semver, options)
+    if (gtltComp > 0) {
+      return null
+    } else if (gtltComp === 0 && (gt.operator !== '>=' || lt.operator !== '<=')) {
+      return null
+    }
+  }
+
+  // will iterate one or zero times
+  for (const eq of eqSet) {
+    if (gt && !satisfies(eq, String(gt), options)) {
+      return null
+    }
+
+    if (lt && !satisfies(eq, String(lt), options)) {
+      return null
+    }
+
+    for (const c of dom) {
+      if (!satisfies(eq, String(c), options)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  let higher, lower
+  let hasDomLT, hasDomGT
+  // if the subset has a prerelease, we need a comparator in the superset
+  // with the same tuple and a prerelease, or it's not a subset
+  let needDomLTPre = lt &&
+    !options.includePrerelease &&
+    lt.semver.prerelease.length ? lt.semver : false
+  let needDomGTPre = gt &&
+    !options.includePrerelease &&
+    gt.semver.prerelease.length ? gt.semver : false
+  // exception: <1.2.3-0 is the same as <1.2.3
+  if (needDomLTPre && needDomLTPre.prerelease.length === 1 &&
+      lt.operator === '<' && needDomLTPre.prerelease[0] === 0) {
+    needDomLTPre = false
+  }
+
+  for (const c of dom) {
+    hasDomGT = hasDomGT || c.operator === '>' || c.operator === '>='
+    hasDomLT = hasDomLT || c.operator === '<' || c.operator === '<='
+    if (gt) {
+      if (needDomGTPre) {
+        if (c.semver.prerelease && c.semver.prerelease.length &&
+            c.semver.major === needDomGTPre.major &&
+            c.semver.minor === needDomGTPre.minor &&
+            c.semver.patch === needDomGTPre.patch) {
+          needDomGTPre = false
+        }
+      }
+      if (c.operator === '>' || c.operator === '>=') {
+        higher = higherGT(gt, c, options)
+        if (higher === c && higher !== gt) {
+          return false
+        }
+      } else if (gt.operator === '>=' && !satisfies(gt.semver, String(c), options)) {
+        return false
+      }
+    }
+    if (lt) {
+      if (needDomLTPre) {
+        if (c.semver.prerelease && c.semver.prerelease.length &&
+            c.semver.major === needDomLTPre.major &&
+            c.semver.minor === needDomLTPre.minor &&
+            c.semver.patch === needDomLTPre.patch) {
+          needDomLTPre = false
+        }
+      }
+      if (c.operator === '<' || c.operator === '<=') {
+        lower = lowerLT(lt, c, options)
+        if (lower === c && lower !== lt) {
+          return false
+        }
+      } else if (lt.operator === '<=' && !satisfies(lt.semver, String(c), options)) {
+        return false
+      }
+    }
+    if (!c.operator && (lt || gt) && gtltComp !== 0) {
+      return false
+    }
+  }
+
+  // if there was a < or >, and nothing in the dom, then must be false
+  // UNLESS it was limited by another range in the other direction.
+  // Eg, >1.0.0 <1.0.1 is still a subset of <2.0.0
+  if (gt && hasDomLT && !lt && gtltComp !== 0) {
+    return false
+  }
+
+  if (lt && hasDomGT && !gt && gtltComp !== 0) {
+    return false
+  }
+
+  // we needed a prerelease range in a specific tuple, but didn't get one
+  // then this isn't a subset.  eg >=1.2.3-pre is not a subset of >=1.0.0,
+  // because it includes prereleases in the 1.2.3 tuple
+  if (needDomGTPre || needDomLTPre) {
+    return false
+  }
+
+  return true
+}
+
+// >=1.2.3 is lower than >1.2.3
+const higherGT = (a, b, options) => {
+  if (!a) {
+    return b
+  }
+  const comp = compare(a.semver, b.semver, options)
+  return comp > 0 ? a
+    : comp < 0 ? b
+    : b.operator === '>' && a.operator === '>=' ? b
+    : a
+}
+
+// <=1.2.3 is higher than <1.2.3
+const lowerLT = (a, b, options) => {
+  if (!a) {
+    return b
+  }
+  const comp = compare(a.semver, b.semver, options)
+  return comp < 0 ? a
+    : comp > 0 ? b
+    : b.operator === '<' && a.operator === '<=' ? b
+    : a
+}
+
+module.exports = subset
+
+
+/***/ }),
+
+/***/ 4203:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const Range = __nccwpck_require__(4506)
+
+// Mostly just for testing and legacy API reasons
+const toComparators = (range, options) =>
+  new Range(range, options).set
+    .map(comp => comp.map(c => c.value).join(' ').trim().split(' '))
+
+module.exports = toComparators
+
+
+/***/ }),
+
+/***/ 1314:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+const Range = __nccwpck_require__(4506)
+const validRange = (range, options) => {
+  try {
+    // Return '*' instead of '' so that truthiness works.
+    // This will throw if it's invalid anyway
+    return new Range(range, options).range || '*'
+  } catch (er) {
+    return null
+  }
+}
+module.exports = validRange
+
+
+/***/ }),
+
+/***/ 4265:
+/***/ ((module) => {
+
+"use strict";
+
+
+module.exports = global;
+
+
+/***/ }),
+
+/***/ 4475:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var defineProperties = __nccwpck_require__(9234);
+
+var implementation = __nccwpck_require__(4265);
+var getPolyfill = __nccwpck_require__(7837);
+var shim = __nccwpck_require__(4676);
+
+var polyfill = getPolyfill();
+
+var getGlobal = function () { return polyfill; };
+
+defineProperties(getGlobal, {
+	getPolyfill: getPolyfill,
+	implementation: implementation,
+	shim: shim
+});
+
+module.exports = getGlobal;
+
+
+/***/ }),
+
+/***/ 7837:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var implementation = __nccwpck_require__(4265);
+
+module.exports = function getPolyfill() {
+	if (typeof global !== 'object' || !global || global.Math !== Math || global.Array !== Array) {
+		return implementation;
+	}
+	return global;
+};
+
+
+/***/ }),
+
+/***/ 4676:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var define = __nccwpck_require__(9234);
+var gOPD = __nccwpck_require__(8501);
+var getPolyfill = __nccwpck_require__(7837);
+
+module.exports = function shimGlobal() {
+	var polyfill = getPolyfill();
+	if (define.supportsDescriptors) {
+		var descriptor = gOPD(polyfill, 'globalThis');
+		if (
+			!descriptor
+			|| (
+				descriptor.configurable
+				&& (descriptor.enumerable || !descriptor.writable || globalThis !== polyfill)
+			)
+		) {
+			Object.defineProperty(polyfill, 'globalThis', {
+				configurable: true,
+				enumerable: false,
+				value: polyfill,
+				writable: true
+			});
+		}
+	} else if (typeof globalThis !== 'object' || globalThis !== polyfill) {
+		polyfill.globalThis = polyfill;
+	}
+	return polyfill;
+};
+
+
+/***/ }),
+
+/***/ 5036:
+/***/ ((module) => {
+
+"use strict";
+
+
+/** @type {import('./gOPD')} */
+module.exports = Object.getOwnPropertyDescriptor;
+
+
+/***/ }),
+
+/***/ 8501:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+/** @type {import('.')} */
+var $gOPD = __nccwpck_require__(5036);
+
+if ($gOPD) {
+	try {
+		$gOPD([], 'length');
+	} catch (e) {
+		// IE 8 has a broken gOPD
+		$gOPD = null;
+	}
+}
+
+module.exports = $gOPD;
 
 
 /***/ }),
@@ -6351,6 +10437,36 @@ exports["default"] = (message) => {
 
 /***/ }),
 
+/***/ 176:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var $defineProperty = __nccwpck_require__(6123);
+
+var hasPropertyDescriptors = function hasPropertyDescriptors() {
+	return !!$defineProperty;
+};
+
+hasPropertyDescriptors.hasArrayLengthDefineBug = function hasArrayLengthDefineBug() {
+	// node v0.6 has a bug where array lengths can be Set but not Defined
+	if (!$defineProperty) {
+		return null;
+	}
+	try {
+		return $defineProperty([], 'length', { value: 1 }).length !== 1;
+	} catch (e) {
+		// In Firefox 4-22, defining length on an array throws an exception.
+		return true;
+	}
+};
+
+module.exports = hasPropertyDescriptors;
+
+
+/***/ }),
+
 /***/ 1002:
 /***/ ((module) => {
 
@@ -8771,6 +12887,40 @@ exports.parse = function (s) {
     }
     return value
   })
+}
+
+
+/***/ }),
+
+/***/ 7073:
+/***/ ((module, exports) => {
+
+exports = module.exports = stringify
+exports.getSerialize = serializer
+
+function stringify(obj, replacer, spaces, cycleReplacer) {
+  return JSON.stringify(obj, serializer(replacer, cycleReplacer), spaces)
+}
+
+function serializer(replacer, cycleReplacer) {
+  var stack = [], keys = []
+
+  if (cycleReplacer == null) cycleReplacer = function(key, value) {
+    if (stack[0] === value) return "[Circular ~]"
+    return "[Circular ~." + keys.slice(0, stack.indexOf(value)).join(".") + "]"
+  }
+
+  return function(key, value) {
+    if (stack.length > 0) {
+      var thisPos = stack.indexOf(this)
+      ~thisPos ? stack.splice(thisPos + 1) : stack.push(this)
+      ~thisPos ? keys.splice(thisPos, Infinity, key) : keys.push(key)
+      if (~stack.indexOf(value)) value = cycleReplacer.call(this, key, value)
+    }
+    else stack.push(value)
+
+    return replacer == null ? value : replacer.call(this, key, value)
+  }
 }
 
 
@@ -16977,6 +21127,112 @@ module.exports = object => {
 
 /***/ }),
 
+/***/ 2239:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+const escapeStringRegexp = __nccwpck_require__(2997);
+
+const regexpCache = new Map();
+
+function makeRegexp(pattern, options) {
+	options = {
+		caseSensitive: false,
+		...options
+	};
+
+	const cacheKey = pattern + JSON.stringify(options);
+
+	if (regexpCache.has(cacheKey)) {
+		return regexpCache.get(cacheKey);
+	}
+
+	const negated = pattern[0] === '!';
+
+	if (negated) {
+		pattern = pattern.slice(1);
+	}
+
+	pattern = escapeStringRegexp(pattern).replace(/\\\*/g, '[\\s\\S]*');
+
+	const regexp = new RegExp(`^${pattern}$`, options.caseSensitive ? '' : 'i');
+	regexp.negated = negated;
+	regexpCache.set(cacheKey, regexp);
+
+	return regexp;
+}
+
+module.exports = (inputs, patterns, options) => {
+	if (!(Array.isArray(inputs) && Array.isArray(patterns))) {
+		throw new TypeError(`Expected two arrays, got ${typeof inputs} ${typeof patterns}`);
+	}
+
+	if (patterns.length === 0) {
+		return inputs;
+	}
+
+	const isFirstPatternNegated = patterns[0][0] === '!';
+
+	patterns = patterns.map(pattern => makeRegexp(pattern, options));
+
+	const result = [];
+
+	for (const input of inputs) {
+		// If first pattern is negated we include everything to match user expectation.
+		let matches = isFirstPatternNegated;
+
+		for (const pattern of patterns) {
+			if (pattern.test(input)) {
+				matches = !pattern.negated;
+			}
+		}
+
+		if (matches) {
+			result.push(input);
+		}
+	}
+
+	return result;
+};
+
+module.exports.isMatch = (input, pattern, options) => {
+	const inputArray = Array.isArray(input) ? input : [input];
+	const patternArray = Array.isArray(pattern) ? pattern : [pattern];
+
+	return inputArray.some(input => {
+		return patternArray.every(pattern => {
+			const regexp = makeRegexp(pattern, options);
+			const matches = regexp.test(input);
+			return regexp.negated ? !matches : matches;
+		});
+	});
+};
+
+
+/***/ }),
+
+/***/ 2997:
+/***/ ((module) => {
+
+"use strict";
+
+
+module.exports = string => {
+	if (typeof string !== 'string') {
+		throw new TypeError('Expected a string');
+	}
+
+	// Escape characters with special meaning either inside or outside character sets.
+	// Use a simple backslash escape when it’s always valid, and a \unnnn escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
+	return string
+		.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+		.replace(/-/g, '\\x2d');
+};
+
+
+/***/ }),
+
 /***/ 2610:
 /***/ ((module) => {
 
@@ -17237,6 +21493,201 @@ const normalizeUrl = (urlString, options) => {
 };
 
 module.exports = normalizeUrl;
+
+
+/***/ }),
+
+/***/ 8435:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var keysShim;
+if (!Object.keys) {
+	// modified from https://github.com/es-shims/es5-shim
+	var has = Object.prototype.hasOwnProperty;
+	var toStr = Object.prototype.toString;
+	var isArgs = __nccwpck_require__(6362); // eslint-disable-line global-require
+	var isEnumerable = Object.prototype.propertyIsEnumerable;
+	var hasDontEnumBug = !isEnumerable.call({ toString: null }, 'toString');
+	var hasProtoEnumBug = isEnumerable.call(function () {}, 'prototype');
+	var dontEnums = [
+		'toString',
+		'toLocaleString',
+		'valueOf',
+		'hasOwnProperty',
+		'isPrototypeOf',
+		'propertyIsEnumerable',
+		'constructor'
+	];
+	var equalsConstructorPrototype = function (o) {
+		var ctor = o.constructor;
+		return ctor && ctor.prototype === o;
+	};
+	var excludedKeys = {
+		$applicationCache: true,
+		$console: true,
+		$external: true,
+		$frame: true,
+		$frameElement: true,
+		$frames: true,
+		$innerHeight: true,
+		$innerWidth: true,
+		$onmozfullscreenchange: true,
+		$onmozfullscreenerror: true,
+		$outerHeight: true,
+		$outerWidth: true,
+		$pageXOffset: true,
+		$pageYOffset: true,
+		$parent: true,
+		$scrollLeft: true,
+		$scrollTop: true,
+		$scrollX: true,
+		$scrollY: true,
+		$self: true,
+		$webkitIndexedDB: true,
+		$webkitStorageInfo: true,
+		$window: true
+	};
+	var hasAutomationEqualityBug = (function () {
+		/* global window */
+		if (typeof window === 'undefined') { return false; }
+		for (var k in window) {
+			try {
+				if (!excludedKeys['$' + k] && has.call(window, k) && window[k] !== null && typeof window[k] === 'object') {
+					try {
+						equalsConstructorPrototype(window[k]);
+					} catch (e) {
+						return true;
+					}
+				}
+			} catch (e) {
+				return true;
+			}
+		}
+		return false;
+	}());
+	var equalsConstructorPrototypeIfNotBuggy = function (o) {
+		/* global window */
+		if (typeof window === 'undefined' || !hasAutomationEqualityBug) {
+			return equalsConstructorPrototype(o);
+		}
+		try {
+			return equalsConstructorPrototype(o);
+		} catch (e) {
+			return false;
+		}
+	};
+
+	keysShim = function keys(object) {
+		var isObject = object !== null && typeof object === 'object';
+		var isFunction = toStr.call(object) === '[object Function]';
+		var isArguments = isArgs(object);
+		var isString = isObject && toStr.call(object) === '[object String]';
+		var theKeys = [];
+
+		if (!isObject && !isFunction && !isArguments) {
+			throw new TypeError('Object.keys called on a non-object');
+		}
+
+		var skipProto = hasProtoEnumBug && isFunction;
+		if (isString && object.length > 0 && !has.call(object, 0)) {
+			for (var i = 0; i < object.length; ++i) {
+				theKeys.push(String(i));
+			}
+		}
+
+		if (isArguments && object.length > 0) {
+			for (var j = 0; j < object.length; ++j) {
+				theKeys.push(String(j));
+			}
+		} else {
+			for (var name in object) {
+				if (!(skipProto && name === 'prototype') && has.call(object, name)) {
+					theKeys.push(String(name));
+				}
+			}
+		}
+
+		if (hasDontEnumBug) {
+			var skipConstructor = equalsConstructorPrototypeIfNotBuggy(object);
+
+			for (var k = 0; k < dontEnums.length; ++k) {
+				if (!(skipConstructor && dontEnums[k] === 'constructor') && has.call(object, dontEnums[k])) {
+					theKeys.push(dontEnums[k]);
+				}
+			}
+		}
+		return theKeys;
+	};
+}
+module.exports = keysShim;
+
+
+/***/ }),
+
+/***/ 137:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+var slice = Array.prototype.slice;
+var isArgs = __nccwpck_require__(6362);
+
+var origKeys = Object.keys;
+var keysShim = origKeys ? function keys(o) { return origKeys(o); } : __nccwpck_require__(8435);
+
+var originalKeys = Object.keys;
+
+keysShim.shim = function shimObjectKeys() {
+	if (Object.keys) {
+		var keysWorksWithArguments = (function () {
+			// Safari 5.0 bug
+			var args = Object.keys(arguments);
+			return args && args.length === arguments.length;
+		}(1, 2));
+		if (!keysWorksWithArguments) {
+			Object.keys = function keys(object) { // eslint-disable-line func-name-matching
+				if (isArgs(object)) {
+					return originalKeys(slice.call(object));
+				}
+				return originalKeys(object);
+			};
+		}
+	} else {
+		Object.keys = keysShim;
+	}
+	return Object.keys || keysShim;
+};
+
+module.exports = keysShim;
+
+
+/***/ }),
+
+/***/ 6362:
+/***/ ((module) => {
+
+"use strict";
+
+
+var toStr = Object.prototype.toString;
+
+module.exports = function isArguments(value) {
+	var str = toStr.call(value);
+	var isArgs = str === '[object Arguments]';
+	if (!isArgs) {
+		isArgs = str !== '[object Array]' &&
+			value !== null &&
+			typeof value === 'object' &&
+			typeof value.length === 'number' &&
+			value.length >= 0 &&
+			toStr.call(value.callee) === '[object Function]';
+	}
+	return isArgs;
+};
 
 
 /***/ }),
@@ -17556,6 +22007,826 @@ class Response extends Readable {
 }
 
 module.exports = Response;
+
+
+/***/ }),
+
+/***/ 6660:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports.logLevels = void 0;
+const logLevels = {
+  debug: 20,
+  error: 50,
+  fatal: 60,
+  info: 30,
+  trace: 10,
+  warn: 40
+};
+exports.logLevels = logLevels;
+//# sourceMappingURL=constants.js.map
+
+/***/ }),
+
+/***/ 2966:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _detectNode = _interopRequireDefault(__nccwpck_require__(5284));
+
+var _globalthis = _interopRequireDefault(__nccwpck_require__(4475));
+
+var _jsonStringifySafe = _interopRequireDefault(__nccwpck_require__(7073));
+
+var _sprintfJs = __nccwpck_require__(1285);
+
+var _constants = __nccwpck_require__(6660);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+const globalThis = (0, _globalthis.default)();
+let domain;
+
+if (_detectNode.default) {
+  // eslint-disable-next-line global-require
+  domain = __nccwpck_require__(3639);
+}
+
+const getParentDomainContext = () => {
+  if (!domain) {
+    return {};
+  }
+
+  const parentRoarrContexts = [];
+  let currentDomain = process.domain; // $FlowFixMe
+
+  if (!currentDomain || !currentDomain.parentDomain) {
+    return {};
+  }
+
+  while (currentDomain && currentDomain.parentDomain) {
+    currentDomain = currentDomain.parentDomain;
+
+    if (currentDomain.roarr && currentDomain.roarr.context) {
+      parentRoarrContexts.push(currentDomain.roarr.context);
+    }
+  }
+
+  let domainContext = {};
+
+  for (const parentRoarrContext of parentRoarrContexts) {
+    domainContext = _objectSpread(_objectSpread({}, domainContext), parentRoarrContext);
+  }
+
+  return domainContext;
+};
+
+const getFirstParentDomainContext = () => {
+  if (!domain) {
+    return {};
+  }
+
+  let currentDomain = process.domain; // $FlowFixMe
+
+  if (currentDomain && currentDomain.roarr && currentDomain.roarr.context) {
+    return currentDomain.roarr.context;
+  } // $FlowFixMe
+
+
+  if (!currentDomain || !currentDomain.parentDomain) {
+    return {};
+  }
+
+  while (currentDomain && currentDomain.parentDomain) {
+    currentDomain = currentDomain.parentDomain;
+
+    if (currentDomain.roarr && currentDomain.roarr.context) {
+      return currentDomain.roarr.context;
+    }
+  }
+
+  return {};
+};
+
+const createLogger = (onMessage, parentContext) => {
+  // eslint-disable-next-line id-length, unicorn/prevent-abbreviations
+  const log = (a, b, c, d, e, f, g, h, i, k) => {
+    const time = Date.now();
+    const sequence = globalThis.ROARR.sequence++;
+    let context;
+    let message;
+
+    if (typeof a === 'string') {
+      context = _objectSpread(_objectSpread({}, getFirstParentDomainContext()), parentContext || {}); // eslint-disable-next-line id-length, object-property-newline
+
+      const args = _extends({}, {
+        a,
+        b,
+        c,
+        d,
+        e,
+        f,
+        g,
+        h,
+        i,
+        k
+      });
+
+      const values = Object.keys(args).map(key => {
+        return args[key];
+      }); // eslint-disable-next-line unicorn/no-reduce
+
+      const hasOnlyOneParameterValued = 1 === values.reduce((accumulator, value) => {
+        // eslint-disable-next-line no-return-assign, no-param-reassign
+        return accumulator += typeof value === 'undefined' ? 0 : 1;
+      }, 0);
+      message = hasOnlyOneParameterValued ? (0, _sprintfJs.sprintf)('%s', a) : (0, _sprintfJs.sprintf)(a, b, c, d, e, f, g, h, i, k);
+    } else {
+      if (typeof b !== 'string') {
+        throw new TypeError('Message must be a string.');
+      }
+
+      context = JSON.parse((0, _jsonStringifySafe.default)(_objectSpread(_objectSpread(_objectSpread({}, getFirstParentDomainContext()), parentContext || {}), a)));
+      message = (0, _sprintfJs.sprintf)(b, c, d, e, f, g, h, i, k);
+    }
+
+    onMessage({
+      context,
+      message,
+      sequence,
+      time,
+      version: '1.0.0'
+    });
+  };
+
+  log.child = context => {
+    if (typeof context === 'function') {
+      return createLogger(message => {
+        if (typeof context !== 'function') {
+          throw new TypeError('Unexpected state.');
+        }
+
+        onMessage(context(message));
+      }, parentContext);
+    }
+
+    return createLogger(onMessage, _objectSpread(_objectSpread(_objectSpread({}, getFirstParentDomainContext()), parentContext), context));
+  };
+
+  log.getContext = () => {
+    return _objectSpread(_objectSpread({}, getFirstParentDomainContext()), parentContext || {});
+  };
+
+  log.adopt = async (routine, context) => {
+    if (!domain) {
+      return routine();
+    }
+
+    const adoptedDomain = domain.create();
+    return adoptedDomain.run(() => {
+      // $FlowFixMe
+      adoptedDomain.roarr = {
+        context: _objectSpread(_objectSpread({}, getParentDomainContext()), context)
+      };
+      return routine();
+    });
+  };
+
+  for (const logLevel of Object.keys(_constants.logLevels)) {
+    // eslint-disable-next-line id-length, unicorn/prevent-abbreviations
+    log[logLevel] = (a, b, c, d, e, f, g, h, i, k) => {
+      return log.child({
+        logLevel: _constants.logLevels[logLevel]
+      })(a, b, c, d, e, f, g, h, i, k);
+    };
+  } // @see https://github.com/facebook/flow/issues/6705
+  // $FlowFixMe
+
+
+  return log;
+};
+
+var _default = createLogger;
+exports["default"] = _default;
+//# sourceMappingURL=createLogger.js.map
+
+/***/ }),
+
+/***/ 6430:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _constants = __nccwpck_require__(6660);
+
+const createMockLogger = (onMessage, parentContext) => {
+  // eslint-disable-next-line id-length, unicorn/prevent-abbreviations, no-unused-vars
+  const log = (a, b, c, d, e, f, g, h, i, k) => {//
+  };
+
+  log.adopt = async routine => {
+    return routine();
+  }; // eslint-disable-next-line no-unused-vars
+
+
+  log.child = context => {
+    return createMockLogger(onMessage, parentContext);
+  };
+
+  log.getContext = () => {
+    return {};
+  };
+
+  for (const logLevel of Object.keys(_constants.logLevels)) {
+    // eslint-disable-next-line id-length, unicorn/prevent-abbreviations
+    log[logLevel] = (a, b, c, d, e, f, g, h, i, k) => {
+      return log.child({
+        logLevel: _constants.logLevels[logLevel]
+      })(a, b, c, d, e, f, g, h, i, k);
+    };
+  } // @see https://github.com/facebook/flow/issues/6705
+  // $FlowFixMe
+
+
+  return log;
+};
+
+var _default = createMockLogger;
+exports["default"] = _default;
+//# sourceMappingURL=createMockLogger.js.map
+
+/***/ }),
+
+/***/ 8318:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+const createBlockingWriter = stream => {
+  return {
+    write: message => {
+      stream.write(message + '\n');
+    }
+  };
+};
+
+const createNodeWriter = () => {
+  // eslint-disable-next-line no-process-env
+  const targetStream = (process.env.ROARR_STREAM || 'STDOUT').toUpperCase();
+  const stream = targetStream.toUpperCase() === 'STDOUT' ? process.stdout : process.stderr;
+  return createBlockingWriter(stream);
+};
+
+var _default = createNodeWriter;
+exports["default"] = _default;
+//# sourceMappingURL=createNodeWriter.js.map
+
+/***/ }),
+
+/***/ 4421:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _detectNode = _interopRequireDefault(__nccwpck_require__(5284));
+
+var _semverCompare = _interopRequireDefault(__nccwpck_require__(2568));
+
+var _package = __nccwpck_require__(8799);
+
+var _createNodeWriter = _interopRequireDefault(__nccwpck_require__(8318));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+// eslint-disable-next-line flowtype/no-weak-types
+const createRoarrInititialGlobalState = currentState => {
+  const versions = (currentState.versions || []).concat();
+  versions.sort(_semverCompare.default);
+  const currentIsLatestVersion = !versions.length || (0, _semverCompare.default)(_package.version, versions[versions.length - 1]) === 1;
+
+  if (!versions.includes(_package.version)) {
+    versions.push(_package.version);
+  }
+
+  versions.sort(_semverCompare.default);
+
+  let newState = _objectSpread(_objectSpread({
+    sequence: 0
+  }, currentState), {}, {
+    versions
+  });
+
+  if (_detectNode.default) {
+    if (currentIsLatestVersion || !newState.write) {
+      newState = _objectSpread(_objectSpread({}, newState), (0, _createNodeWriter.default)());
+    }
+  }
+
+  return newState;
+};
+
+var _default = createRoarrInititialGlobalState;
+exports["default"] = _default;
+//# sourceMappingURL=createRoarrInititialGlobalState.js.map
+
+/***/ }),
+
+/***/ 233:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "createLogger", ({
+  enumerable: true,
+  get: function () {
+    return _createLogger.default;
+  }
+}));
+Object.defineProperty(exports, "createMockLogger", ({
+  enumerable: true,
+  get: function () {
+    return _createMockLogger.default;
+  }
+}));
+Object.defineProperty(exports, "createRoarrInititialGlobalState", ({
+  enumerable: true,
+  get: function () {
+    return _createRoarrInititialGlobalState.default;
+  }
+}));
+
+var _createLogger = _interopRequireDefault(__nccwpck_require__(2966));
+
+var _createMockLogger = _interopRequireDefault(__nccwpck_require__(6430));
+
+var _createRoarrInititialGlobalState = _interopRequireDefault(__nccwpck_require__(4421));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+//# sourceMappingURL=index.js.map
+
+/***/ }),
+
+/***/ 5191:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = exports.ROARR = void 0;
+
+var _boolean = __nccwpck_require__(1253);
+
+var _detectNode = _interopRequireDefault(__nccwpck_require__(5284));
+
+var _globalthis = _interopRequireDefault(__nccwpck_require__(4475));
+
+var _factories = __nccwpck_require__(233);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const globalThis = (0, _globalthis.default)();
+const ROARR = globalThis.ROARR = (0, _factories.createRoarrInititialGlobalState)(globalThis.ROARR || {});
+exports.ROARR = ROARR;
+let logFactory = _factories.createLogger;
+
+if (_detectNode.default) {
+  // eslint-disable-next-line no-process-env
+  const enabled = (0, _boolean.boolean)(process.env.ROARR_LOG || '');
+
+  if (!enabled) {
+    logFactory = _factories.createMockLogger;
+  }
+}
+
+var _default = logFactory(message => {
+  if (ROARR.write) {
+    // Stringify message as soon as it is received to prevent
+    // properties of the context from being modified by reference.
+    const body = JSON.stringify(message);
+    ROARR.write(body);
+  }
+});
+
+exports["default"] = _default;
+//# sourceMappingURL=log.js.map
+
+/***/ }),
+
+/***/ 1285:
+/***/ ((__unused_webpack_module, exports) => {
+
+/* global window, exports, define */
+
+!function() {
+    'use strict'
+
+    var re = {
+        not_string: /[^s]/,
+        not_bool: /[^t]/,
+        not_type: /[^T]/,
+        not_primitive: /[^v]/,
+        number: /[diefg]/,
+        numeric_arg: /[bcdiefguxX]/,
+        json: /[j]/,
+        not_json: /[^j]/,
+        text: /^[^\x25]+/,
+        modulo: /^\x25{2}/,
+        placeholder: /^\x25(?:([1-9]\d*)\$|\(([^)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijostTuvxX])/,
+        key: /^([a-z_][a-z_\d]*)/i,
+        key_access: /^\.([a-z_][a-z_\d]*)/i,
+        index_access: /^\[(\d+)\]/,
+        sign: /^[+-]/
+    }
+
+    function sprintf(key) {
+        // `arguments` is not an array, but should be fine for this call
+        return sprintf_format(sprintf_parse(key), arguments)
+    }
+
+    function vsprintf(fmt, argv) {
+        return sprintf.apply(null, [fmt].concat(argv || []))
+    }
+
+    function sprintf_format(parse_tree, argv) {
+        var cursor = 1, tree_length = parse_tree.length, arg, output = '', i, k, ph, pad, pad_character, pad_length, is_positive, sign
+        for (i = 0; i < tree_length; i++) {
+            if (typeof parse_tree[i] === 'string') {
+                output += parse_tree[i]
+            }
+            else if (typeof parse_tree[i] === 'object') {
+                ph = parse_tree[i] // convenience purposes only
+                if (ph.keys) { // keyword argument
+                    arg = argv[cursor]
+                    for (k = 0; k < ph.keys.length; k++) {
+                        if (arg == undefined) {
+                            throw new Error(sprintf('[sprintf] Cannot access property "%s" of undefined value "%s"', ph.keys[k], ph.keys[k-1]))
+                        }
+                        arg = arg[ph.keys[k]]
+                    }
+                }
+                else if (ph.param_no) { // positional argument (explicit)
+                    arg = argv[ph.param_no]
+                }
+                else { // positional argument (implicit)
+                    arg = argv[cursor++]
+                }
+
+                if (re.not_type.test(ph.type) && re.not_primitive.test(ph.type) && arg instanceof Function) {
+                    arg = arg()
+                }
+
+                if (re.numeric_arg.test(ph.type) && (typeof arg !== 'number' && isNaN(arg))) {
+                    throw new TypeError(sprintf('[sprintf] expecting number but found %T', arg))
+                }
+
+                if (re.number.test(ph.type)) {
+                    is_positive = arg >= 0
+                }
+
+                switch (ph.type) {
+                    case 'b':
+                        arg = parseInt(arg, 10).toString(2)
+                        break
+                    case 'c':
+                        arg = String.fromCharCode(parseInt(arg, 10))
+                        break
+                    case 'd':
+                    case 'i':
+                        arg = parseInt(arg, 10)
+                        break
+                    case 'j':
+                        arg = JSON.stringify(arg, null, ph.width ? parseInt(ph.width) : 0)
+                        break
+                    case 'e':
+                        arg = ph.precision ? parseFloat(arg).toExponential(ph.precision) : parseFloat(arg).toExponential()
+                        break
+                    case 'f':
+                        arg = ph.precision ? parseFloat(arg).toFixed(ph.precision) : parseFloat(arg)
+                        break
+                    case 'g':
+                        arg = ph.precision ? String(Number(arg.toPrecision(ph.precision))) : parseFloat(arg)
+                        break
+                    case 'o':
+                        arg = (parseInt(arg, 10) >>> 0).toString(8)
+                        break
+                    case 's':
+                        arg = String(arg)
+                        arg = (ph.precision ? arg.substring(0, ph.precision) : arg)
+                        break
+                    case 't':
+                        arg = String(!!arg)
+                        arg = (ph.precision ? arg.substring(0, ph.precision) : arg)
+                        break
+                    case 'T':
+                        arg = Object.prototype.toString.call(arg).slice(8, -1).toLowerCase()
+                        arg = (ph.precision ? arg.substring(0, ph.precision) : arg)
+                        break
+                    case 'u':
+                        arg = parseInt(arg, 10) >>> 0
+                        break
+                    case 'v':
+                        arg = arg.valueOf()
+                        arg = (ph.precision ? arg.substring(0, ph.precision) : arg)
+                        break
+                    case 'x':
+                        arg = (parseInt(arg, 10) >>> 0).toString(16)
+                        break
+                    case 'X':
+                        arg = (parseInt(arg, 10) >>> 0).toString(16).toUpperCase()
+                        break
+                }
+                if (re.json.test(ph.type)) {
+                    output += arg
+                }
+                else {
+                    if (re.number.test(ph.type) && (!is_positive || ph.sign)) {
+                        sign = is_positive ? '+' : '-'
+                        arg = arg.toString().replace(re.sign, '')
+                    }
+                    else {
+                        sign = ''
+                    }
+                    pad_character = ph.pad_char ? ph.pad_char === '0' ? '0' : ph.pad_char.charAt(1) : ' '
+                    pad_length = ph.width - (sign + arg).length
+                    pad = ph.width ? (pad_length > 0 ? pad_character.repeat(pad_length) : '') : ''
+                    output += ph.align ? sign + arg + pad : (pad_character === '0' ? sign + pad + arg : pad + sign + arg)
+                }
+            }
+        }
+        return output
+    }
+
+    var sprintf_cache = Object.create(null)
+
+    function sprintf_parse(fmt) {
+        if (sprintf_cache[fmt]) {
+            return sprintf_cache[fmt]
+        }
+
+        var _fmt = fmt, match, parse_tree = [], arg_names = 0
+        while (_fmt) {
+            if ((match = re.text.exec(_fmt)) !== null) {
+                parse_tree.push(match[0])
+            }
+            else if ((match = re.modulo.exec(_fmt)) !== null) {
+                parse_tree.push('%')
+            }
+            else if ((match = re.placeholder.exec(_fmt)) !== null) {
+                if (match[2]) {
+                    arg_names |= 1
+                    var field_list = [], replacement_field = match[2], field_match = []
+                    if ((field_match = re.key.exec(replacement_field)) !== null) {
+                        field_list.push(field_match[1])
+                        while ((replacement_field = replacement_field.substring(field_match[0].length)) !== '') {
+                            if ((field_match = re.key_access.exec(replacement_field)) !== null) {
+                                field_list.push(field_match[1])
+                            }
+                            else if ((field_match = re.index_access.exec(replacement_field)) !== null) {
+                                field_list.push(field_match[1])
+                            }
+                            else {
+                                throw new SyntaxError('[sprintf] failed to parse named argument key')
+                            }
+                        }
+                    }
+                    else {
+                        throw new SyntaxError('[sprintf] failed to parse named argument key')
+                    }
+                    match[2] = field_list
+                }
+                else {
+                    arg_names |= 2
+                }
+                if (arg_names === 3) {
+                    throw new Error('[sprintf] mixing positional and named placeholders is not (yet) supported')
+                }
+
+                parse_tree.push(
+                    {
+                        placeholder: match[0],
+                        param_no:    match[1],
+                        keys:        match[2],
+                        sign:        match[3],
+                        pad_char:    match[4],
+                        align:       match[5],
+                        width:       match[6],
+                        precision:   match[7],
+                        type:        match[8]
+                    }
+                )
+            }
+            else {
+                throw new SyntaxError('[sprintf] unexpected placeholder')
+            }
+            _fmt = _fmt.substring(match[0].length)
+        }
+        return sprintf_cache[fmt] = parse_tree
+    }
+
+    /**
+     * export to either browser or node.js
+     */
+    /* eslint-disable quote-props */
+    if (true) {
+        exports.sprintf = sprintf
+        exports.vsprintf = vsprintf
+    }
+    if (typeof window !== 'undefined') {
+        window['sprintf'] = sprintf
+        window['vsprintf'] = vsprintf
+
+        if (typeof define === 'function' && define['amd']) {
+            define(function() {
+                return {
+                    'sprintf': sprintf,
+                    'vsprintf': vsprintf
+                }
+            })
+        }
+    }
+    /* eslint-enable quote-props */
+}(); // eslint-disable-line
+
+
+/***/ }),
+
+/***/ 2568:
+/***/ ((module) => {
+
+module.exports = function cmp (a, b) {
+    var pa = a.split('.');
+    var pb = b.split('.');
+    for (var i = 0; i < 3; i++) {
+        var na = Number(pa[i]);
+        var nb = Number(pb[i]);
+        if (na > nb) return 1;
+        if (nb > na) return -1;
+        if (!isNaN(na) && isNaN(nb)) return 1;
+        if (isNaN(na) && !isNaN(nb)) return -1;
+    }
+    return 0;
+};
+
+
+/***/ }),
+
+/***/ 8604:
+/***/ ((module) => {
+
+"use strict";
+
+
+class NonError extends Error {
+	constructor(message) {
+		super(NonError._prepareSuperMessage(message));
+		Object.defineProperty(this, 'name', {
+			value: 'NonError',
+			configurable: true,
+			writable: true
+		});
+
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, NonError);
+		}
+	}
+
+	static _prepareSuperMessage(message) {
+		try {
+			return JSON.stringify(message);
+		} catch (_) {
+			return String(message);
+		}
+	}
+}
+
+const commonProperties = [
+	{property: 'name', enumerable: false},
+	{property: 'message', enumerable: false},
+	{property: 'stack', enumerable: false},
+	{property: 'code', enumerable: true}
+];
+
+const destroyCircular = ({from, seen, to_, forceEnumerable}) => {
+	const to = to_ || (Array.isArray(from) ? [] : {});
+
+	seen.push(from);
+
+	for (const [key, value] of Object.entries(from)) {
+		if (typeof value === 'function') {
+			continue;
+		}
+
+		if (!value || typeof value !== 'object') {
+			to[key] = value;
+			continue;
+		}
+
+		if (!seen.includes(from[key])) {
+			to[key] = destroyCircular({from: from[key], seen: seen.slice(), forceEnumerable});
+			continue;
+		}
+
+		to[key] = '[Circular]';
+	}
+
+	for (const {property, enumerable} of commonProperties) {
+		if (typeof from[property] === 'string') {
+			Object.defineProperty(to, property, {
+				value: from[property],
+				enumerable: forceEnumerable ? true : enumerable,
+				configurable: true,
+				writable: true
+			});
+		}
+	}
+
+	return to;
+};
+
+const serializeError = value => {
+	if (typeof value === 'object' && value !== null) {
+		return destroyCircular({from: value, seen: [], forceEnumerable: true});
+	}
+
+	// People sometimes throw things besides Error objects…
+	if (typeof value === 'function') {
+		// `JSON.stringify()` discards functions. We do too, unless a function is thrown directly.
+		return `[Function: ${(value.name || 'anonymous')}]`;
+	}
+
+	return value;
+};
+
+const deserializeError = value => {
+	if (value instanceof Error) {
+		return value;
+	}
+
+	if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+		const newError = new Error();
+		destroyCircular({from: value, seen: [], to_: newError});
+		return newError;
+	}
+
+	return new NonError(value);
+};
+
+module.exports = {
+	serializeError,
+	deserializeError
+};
 
 
 /***/ }),
@@ -18536,7 +23807,8 @@ const got = (__nccwpck_require__(3061)["default"]);
 const jsonata = __nccwpck_require__(4245);
 const { normalizeOutputKey } = __nccwpck_require__(1608);
 const { WILDCARD, WILDCARD_UPPERCASE } = __nccwpck_require__(4438);
-
+const { enableProxy } = __nccwpck_require__(3537)
+enableProxy();
 const { auth: { retrieveToken }, secrets: { getSecrets }, pki: { getCertificates } } = __nccwpck_require__(4351);
 
 const AUTH_METHODS = ['approle', 'token', 'github', 'jwt', 'kubernetes', 'ldap', 'userpass'];
@@ -19113,6 +24385,34 @@ module.exports = {
 
 /***/ }),
 
+/***/ 3537:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const {bootstrap} = __nccwpck_require__(6769);
+const core = __nccwpck_require__(2186);
+const MAJOR_NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10);
+
+/**
+ * Will enable global-agent proxy if the necessary
+ * [global-agent environment variables](https://github.com/gajus/global-agent?tab=readme-ov-file#environment-variables)
+ * has been set.
+ * The global-agent bootstrap routine guards against multiple initializations of global-agent
+ * Important note: `global-agent` only works with Node.js v10 and above.
+ */
+function enableProxy() {
+  if (MAJOR_NODEJS_VERSION >= 10) {
+    bootstrap();
+  } else {
+    core.debug('proxy configuration does not work with Node.js below v10')
+  }
+}
+
+module.exports = {
+  enableProxy
+}
+
+/***/ }),
+
 /***/ 8452:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -19357,6 +24657,14 @@ module.exports = require("dns");
 
 /***/ }),
 
+/***/ 3639:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("domain");
+
+/***/ }),
+
 /***/ 2361:
 /***/ ((module) => {
 
@@ -19458,6 +24766,14 @@ module.exports = require("util");
 
 "use strict";
 module.exports = require("zlib");
+
+/***/ }),
+
+/***/ 8799:
+/***/ ((module) => {
+
+"use strict";
+module.exports = JSON.parse('{"author":{"email":"gajus@gajus.com","name":"Gajus Kuizinas","url":"http://gajus.com"},"ava":{"babel":{"compileAsTests":["test/helpers/**/*"]},"files":["test/roarr/**/*"],"require":["@babel/register"]},"dependencies":{"boolean":"^3.0.1","detect-node":"^2.0.4","globalthis":"^1.0.1","json-stringify-safe":"^5.0.1","semver-compare":"^1.0.0","sprintf-js":"^1.1.2"},"description":"JSON logger for Node.js and browser.","devDependencies":{"@ava/babel":"^1.0.1","@babel/cli":"^7.11.6","@babel/core":"^7.11.6","@babel/node":"^7.10.5","@babel/plugin-transform-flow-strip-types":"^7.10.4","@babel/preset-env":"^7.11.5","@babel/register":"^7.11.5","ava":"^3.12.1","babel-plugin-istanbul":"^6.0.0","babel-plugin-transform-export-default-name":"^2.0.4","coveralls":"^3.1.0","domain-parent":"^1.0.0","eslint":"^7.9.0","eslint-config-canonical":"^24.1.1","flow-bin":"^0.133.0","flow-copy-source":"^2.0.9","gitdown":"^3.1.3","husky":"^4.3.0","nyc":"^15.1.0","semantic-release":"^17.1.1"},"engines":{"node":">=8.0"},"husky":{"hooks":{"pre-commit":"npm run lint && npm run test && npm run build","pre-push":"gitdown ./.README/README.md --output-file ./README.md --check"}},"keywords":["log","logger","json"],"main":"./dist/log.js","name":"roarr","nyc":{"include":["src/**/*.js"],"instrument":false,"reporter":["text-lcov"],"require":["@babel/register"],"sourceMap":false},"license":"BSD-3-Clause","repository":{"type":"git","url":"git@github.com:gajus/roarr.git"},"scripts":{"build":"rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps && flow-copy-source src dist","create-readme":"gitdown ./.README/README.md --output-file ./README.md","dev":"NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps --watch","lint":"eslint ./src ./test && flow","test":"NODE_ENV=test ava --serial --verbose"},"version":"2.15.4"}');
 
 /***/ })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
+                "global-agent": "^3.0.0",
                 "got": "^11.8.6",
                 "jsonata": "^2.0.3",
                 "jsrsasign": "^11.1.0"
@@ -1435,6 +1436,13 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
+        "node_modules/boolean": {
+            "version": "3.2.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/boolean/-/boolean-3.2.0.tgz",
+            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "license": "MIT"
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1898,6 +1906,40 @@
                 "node": ">=10"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1926,6 +1968,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/detect-node": {
+            "version": "2.1.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+            "license": "MIT"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -2011,7 +2059,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2021,7 +2068,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2039,6 +2085,12 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+            "license": "MIT"
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -2338,6 +2390,35 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/global-agent": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/global-agent/-/global-agent-3.0.0.tgz",
+            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "boolean": "^3.0.1",
+                "es6-error": "^4.1.1",
+                "matcher": "^3.0.0",
+                "roarr": "^2.15.3",
+                "semver": "^7.3.2",
+                "serialize-error": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            }
+        },
+        "node_modules/global-agent/node_modules/semver": {
+            "version": "7.7.2",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2347,11 +2428,26 @@
                 "node": ">=4"
             }
         },
+        "node_modules/globalthis": {
+            "version": "1.0.4",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -2397,6 +2493,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -3354,6 +3462,12 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "license": "ISC"
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3500,6 +3614,30 @@
             "dev": true,
             "dependencies": {
                 "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/matcher": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/matcher/-/matcher-3.0.0.tgz",
+            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/matcher/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/math-intrinsics": {
@@ -3729,6 +3867,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/on-finished": {
@@ -4104,6 +4251,29 @@
                 "lowercase-keys": "^2.0.0"
             }
         },
+        "node_modules/roarr": {
+            "version": "2.15.4",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/roarr/-/roarr-2.15.4.tgz",
+            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "boolean": "^3.0.1",
+                "detect-node": "^2.0.4",
+                "globalthis": "^1.0.1",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0",
+                "sprintf-js": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/roarr/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4118,6 +4288,39 @@
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+            "license": "MIT"
+        },
+        "node_modules/serialize-error": {
+            "version": "7.0.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/serialize-error/-/serialize-error-7.0.1.tgz",
+            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/serialize-error/node_modules/type-fest": {
+            "version": "0.13.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/type-fest/-/type-fest-0.13.1.tgz",
+            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/setprototypeof": {
@@ -5808,6 +6011,11 @@
                 }
             }
         },
+        "boolean": {
+            "version": "3.2.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/boolean/-/boolean-3.2.0.tgz",
+            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -6125,6 +6333,26 @@
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
             "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
         },
+        "define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "requires": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            }
+        },
+        "define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "requires": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            }
+        },
         "depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6142,6 +6370,11 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
+        },
+        "detect-node": {
+            "version": "2.1.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
         },
         "diff-sequences": {
             "version": "29.6.3",
@@ -6210,14 +6443,12 @@
         "es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
         },
         "es-errors": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
         },
         "es-object-atoms": {
             "version": "1.0.0",
@@ -6227,6 +6458,11 @@
             "requires": {
                 "es-errors": "^1.3.0"
             }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
         },
         "escalade": {
             "version": "3.1.1",
@@ -6448,17 +6684,45 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "global-agent": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/global-agent/-/global-agent-3.0.0.tgz",
+            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+            "requires": {
+                "boolean": "^3.0.1",
+                "es6-error": "^4.1.1",
+                "matcher": "^3.0.0",
+                "roarr": "^2.15.3",
+                "semver": "^7.3.2",
+                "serialize-error": "^7.0.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.7.2",
+                    "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/semver/-/semver-7.7.2.tgz",
+                    "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
+                }
+            }
+        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
         },
+        "globalthis": {
+            "version": "1.0.4",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+            "requires": {
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
+            }
+        },
         "gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
         },
         "got": {
             "version": "11.8.6",
@@ -6489,6 +6753,14 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true
+        },
+        "has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "requires": {
+                "es-define-property": "^1.0.0"
+            }
         },
         "has-symbols": {
             "version": "1.1.0",
@@ -7214,6 +7486,11 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+        },
         "json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7322,6 +7599,21 @@
             "dev": true,
             "requires": {
                 "tmpl": "1.0.5"
+            }
+        },
+        "matcher": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/matcher/-/matcher-3.0.0.tgz",
+            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+            "requires": {
+                "escape-string-regexp": "^4.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+                }
             }
         },
         "math-intrinsics": {
@@ -7486,6 +7778,11 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
             "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
             "dev": true
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "on-finished": {
             "version": "2.4.1",
@@ -7750,6 +8047,26 @@
                 "lowercase-keys": "^2.0.0"
             }
         },
+        "roarr": {
+            "version": "2.15.4",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/roarr/-/roarr-2.15.4.tgz",
+            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+            "requires": {
+                "boolean": "^3.0.1",
+                "detect-node": "^2.0.4",
+                "globalthis": "^1.0.1",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0",
+                "sprintf-js": "^1.1.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.1.3",
+                    "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/sprintf-js/-/sprintf-js-1.1.3.tgz",
+                    "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+                }
+            }
+        },
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7761,6 +8078,26 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true
+        },
+        "semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+        },
+        "serialize-error": {
+            "version": "7.0.1",
+            "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/serialize-error/-/serialize-error-7.0.1.tgz",
+            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+            "requires": {
+                "type-fest": "^0.13.1"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.13.1",
+                    "resolved": "https://artifactory.datev.de/artifactory/api/npm/npm-mirror/type-fest/-/type-fest-0.13.1.tgz",
+                    "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+                }
+            }
         },
         "setprototypeof": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     },
     "homepage": "https://github.com/hashicorp/vault-action#readme",
     "dependencies": {
+        "global-agent": "^3.0.0",
         "got": "^11.8.6",
         "jsonata": "^2.0.3",
         "jsrsasign": "^11.1.0"

--- a/src/action.js
+++ b/src/action.js
@@ -5,7 +5,8 @@ const got = require('got').default;
 const jsonata = require('jsonata');
 const { normalizeOutputKey } = require('./utils');
 const { WILDCARD, WILDCARD_UPPERCASE } = require('./constants');
-
+const { enableProxy } = require('./proxy')
+enableProxy();
 const { auth: { retrieveToken }, secrets: { getSecrets }, pki: { getCertificates } } = require('./index');
 
 const AUTH_METHODS = ['approle', 'token', 'github', 'jwt', 'kubernetes', 'ldap', 'userpass'];

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,0 +1,24 @@
+const {bootstrap} = require('global-agent');
+const core = require("@actions/core");
+const MAJOR_NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10);
+
+/**
+ * Will enable global-agent proxy if the necessary
+ * [global-agent environment variables](https://github.com/gajus/global-agent?tab=readme-ov-file#environment-variables)
+ * has been set.
+ * Important note: `global-agent` only works with Node.js v10 and above.
+ * Node.js versions below v10 are not supported
+ *
+ * The bootstrap routine guards against multiple initializations of global-agent
+ */
+function enableProxy() {
+  if (MAJOR_NODEJS_VERSION >= 10) {
+    bootstrap();
+  } else {
+    core.debug('proxy configuration does not work with Node.js below v10')
+  }
+}
+
+module.exports = {
+  enableProxy
+}

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -6,10 +6,8 @@ const MAJOR_NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10
  * Will enable global-agent proxy if the necessary
  * [global-agent environment variables](https://github.com/gajus/global-agent?tab=readme-ov-file#environment-variables)
  * has been set.
+ * The global-agent bootstrap routine guards against multiple initializations of global-agent
  * Important note: `global-agent` only works with Node.js v10 and above.
- * Node.js versions below v10 are not supported
- *
- * The bootstrap routine guards against multiple initializations of global-agent
  */
 function enableProxy() {
   if (MAJOR_NODEJS_VERSION >= 10) {

--- a/src/proxy.test.js
+++ b/src/proxy.test.js
@@ -1,0 +1,72 @@
+const {enableProxy } = require('./proxy')
+const got = require('got');
+
+describe('global-agent proxy support works as expected', () => {
+
+  it('should fail with a request specific RequestError if got tries to request any-host without proxy', async () => {
+    const expectedRequestErrorMessage = `getaddrinfo ENOTFOUND any-host`;
+    try {
+      await got.get('http://any-host')
+      throw new Error('Test fail if the got request succeeds against expectation');
+    } catch(e) {
+      expect(e).toBeDefined();
+      expect(e.message).toEqual(expectedRequestErrorMessage);
+      expect(e.code).toEqual('ENOTFOUND');
+    }
+  });
+
+  it('should fail with a proxy specific RequestError if got tries to request through the defined proxy', async () => {
+    const PROXY_HOST = "my-test-proxy-server";
+    process.env.GLOBAL_AGENT_HTTP_PROXY = `http://${PROXY_HOST}:8000`;
+    enableProxy();
+    const expectedRequestErrorMessage = `getaddrinfo ENOTFOUND ${PROXY_HOST}`;
+    try {
+      await got.get('http://any-host')
+      throw new Error('Test fail if the got request succeeds against expectation');
+    } catch(e) {
+      expect(e).toBeDefined();
+      expect(e.message).toEqual(expectedRequestErrorMessage);
+      expect(e.code).toEqual('ENOTFOUND');
+    }
+  });
+
+  it('should fail with a request specific RequestError if HTTP_PROXY URL is undefined', async () => {
+    // set proxy url to undefined at runtime
+    global.GLOBAL_AGENT.HTTP_PROXY = undefined;
+    const expectedRequestErrorMessage = `getaddrinfo ENOTFOUND any-host`;
+    try {
+      await got.get('http://any-host')
+      throw new Error('Test fail if the got request succeeds against expectation');
+    } catch(e) {
+      expect(e).toBeDefined();
+      expect(e.message).toEqual(expectedRequestErrorMessage);
+      expect(e.code).toEqual('ENOTFOUND');
+    }
+  });
+
+  it('should fail with a request specific RequestError if HTTP_PROXY URL is empty', async () => {
+    // set proxy url to empty string at runtime
+    global.GLOBAL_AGENT.HTTP_PROXY = '';
+    const expectedRequestErrorMessage = `getaddrinfo ENOTFOUND any-host`;
+    try {
+      await got.get('http://any-host')
+      throw new Error('Test fail if the got request succeeds against expectation');
+    } catch(e) {
+      expect(e).toBeDefined();
+      expect(e.message).toEqual(expectedRequestErrorMessage);
+      expect(e.code).toEqual('ENOTFOUND');
+    }
+  });
+
+  it('should fail with UNEXPECTED_STATE_ERROR if HTTP_PROXY URL protocol does not start with "http:"', async () => {
+    // set proxy url to string with blanks at runtime
+    global.GLOBAL_AGENT.HTTP_PROXY = 'file://';
+    try {
+      await got.get('http://any-host')
+      throw new Error('Test fail if the got request succeeds against expectation');
+    } catch(e) {
+      expect(e).toBeDefined();
+      expect(e.code).toEqual('UNEXPECTED_STATE_ERROR');
+    }
+  });
+})


### PR DESCRIPTION
### Description
Adds proxy support through global-agent:   
If your action runs on a self-hosted GitHub Runner behind a proxy, you can enable proxy support through [global-agent environment variables](https://github.com/gajus/global-agent?tab=readme-ov-file#environment-variables),
which supports the `got` request library (https://github.com/gajus/global-agent?tab=readme-ov-file#supported-libraries)

With the exception of the `global-agent` bootstrap, this solution is non-invasive and does not affect the implementation of the vault action;
it depends only on the integration between [global-agent](https://github.com/gajus/global-agent) and the [got](https://github.com/sindresorhus/got) request client.  

An alternative implementation proposal with `hpagent` can be found here: 
- https://github.com/hashicorp/vault-action/pull/374

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request
