### PR TITLE
README.md: Removing jwtGithubAudience default

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,8 +630,7 @@ Password for key stored in `jwtPrivateKey` (if needed).
 
 ### `jwtGithubAudience`
 
-**Type: `string`**\
-**Default: `sigstore`**
+**Type: `string`**
 
 Identifies the recipient ("aud" claim) that the JWT is intended for.
 


### PR DESCRIPTION


### Description
This PR updates the `README.md` fle by removing the documented default value for the `jwtGithubAudience` parameter in the README.md to match the action.

Ref: https://github.com/hashicorp/vault-action/blob/main/action.yml#L85-L87


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #558


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [N/A] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [N/A] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
