### PR TITLE
Disable environment export by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+Major (Breaking Change):
+
+* `exportEnv` now defaults to `false`. If you relied on that feature please switch it to `true` or reference via outputs.
+  This change was made to facilitate a better default supply chain security position. (https://github.com/hashicorp/vault-action/pull/598)
+
 ## 3.4.0 (June 13, 2025)
 
 Bugs:

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ steps:
     run: "my-cli --token '${{ steps.secrets.outputs.npmToken }}'"
 ```
 
-_**Note:** If you'd like to only use outputs and disable automatic environment variables, you can set the `exportEnv` option to `false`._
+_**Note:** By default, environment variable export is disabled. If you’d like to enable automatic environment variables, you can set the `exportEnv` option to `true`._
 
 ### Set Output Variable Name
 
@@ -403,7 +403,7 @@ with:
     secret/data/ci/aws * | MYAPP_ ;
 ```
 
-When using the `exportEnv` option all exported keys will be normalized to uppercase. For example, the key `SecretKey` would be exported as `MYAPP_SECRETKEY`.
+When using the `exportEnv` option (when enabled), all exported keys will be normalized to uppercase. For example, the key `SecretKey` would be exported as `MYAPP_SECRETKEY`.
 You can disable uppercase normalization by specifying double asterisks `**` in the selector path:
 
 ```yaml
@@ -675,9 +675,9 @@ A string of newline separated extra headers to include on every request.
 ### `exportEnv`
 
 **Type: `string`**\
-**Default: `true`**
+**Default: `false`**
 
-Whether or not to export secrets as environment variables.
+Whether or not to export secrets as environment variables.  This is disabled by default and must be explicitly enabled if environment variable export is desired.
 
 ### `exportToken`
 

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ inputs:
     required: false
   exportEnv:
     description: 'Whether or not export secrets as environment variables.'
-    default: 'true'
+    default: 'false'
     required: false
   exportToken:
     description: 'Whether or not export Vault token as environment variables.'


### PR DESCRIPTION
### Description
This PR fixes #597, by setting `exportEnv` to a default of `false` for supply chain security hardening


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)

### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
