### PR TITLE
Handle undefined ca_chain with optional chaining

### DIFF
--- a/src/pki.js
+++ b/src/pki.js
@@ -11,7 +11,7 @@ const outputMap = {
     cert: { key: 'certificate', tx: (v) => v },
     key: { key: 'private_key', tx: (v) => v },
     ca: { key: 'issuing_ca', tx: (v) => v },
-    ca_chain: { key: 'ca_chain', tx: (v) => v.join('\n') },
+    ca_chain: { key: 'ca_chain', tx: (v) => v?.join('\n') ?? '' },
 };
 
 /**


### PR DESCRIPTION


### Description

This fix handles pki responses from vault that don't contain a `ca_chain` property

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #609

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
