### PR TITLE
Handle missing PKI ca_chain responses

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19069,7 +19069,7 @@ const outputMap = {
     cert: { key: 'certificate', tx: (v) => v },
     key: { key: 'private_key', tx: (v) => v },
     ca: { key: 'issuing_ca', tx: (v) => v },
-    ca_chain: { key: 'ca_chain', tx: (v) => v.join('\n') },
+    ca_chain: { key: 'ca_chain', tx: (v) => v.join('\n'), optional: true },
 };
 
 /**
@@ -19118,7 +19118,12 @@ async function getCertificates(pkiRequests, client) {
         core.info(`✔ Successfully generated certificate (serial number ${body.data.serial_number})`);
 
         Object.entries(outputMap).forEach(([key, value]) => {
-            const val = value.tx(body.data[value.key]);
+            const rawValue = body.data[value.key];
+            if (value.optional && rawValue == null) {
+                return;
+            }
+
+            const val = value.tx(rawValue);
             results.push({
                 request: {
                     ...pkiRequest,
@@ -19137,6 +19142,7 @@ async function getCertificates(pkiRequests, client) {
 module.exports = {
     getCertificates,
 };
+
 
 /***/ }),
 

--- a/src/pki.js
+++ b/src/pki.js
@@ -11,7 +11,7 @@ const outputMap = {
     cert: { key: 'certificate', tx: (v) => v },
     key: { key: 'private_key', tx: (v) => v },
     ca: { key: 'issuing_ca', tx: (v) => v },
-    ca_chain: { key: 'ca_chain', tx: (v) => v.join('\n') },
+    ca_chain: { key: 'ca_chain', tx: (v) => v.join('\n'), optional: true },
 };
 
 /**
@@ -60,7 +60,12 @@ async function getCertificates(pkiRequests, client) {
         core.info(`✔ Successfully generated certificate (serial number ${body.data.serial_number})`);
 
         Object.entries(outputMap).forEach(([key, value]) => {
-            const val = value.tx(body.data[value.key]);
+            const rawValue = body.data[value.key];
+            if (value.optional && rawValue == null) {
+                return;
+            }
+
+            const val = value.tx(rawValue);
             results.push({
                 request: {
                     ...pkiRequest,

--- a/src/pki.test.js
+++ b/src/pki.test.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright IBM Corp. 2019, 2026
+ * SPDX-License-Identifier: MIT
+ */
+
+jest.mock('@actions/core');
+
+const { getCertificates } = require('./pki');
+
+describe('getCertificates', () => {
+    const pkiRequest = {
+        path: 'pki/issue/Test',
+        parameters: { common_name: 'test', ttl: '1h' },
+        envVarName: 'TEST',
+        outputVarName: 'test',
+    };
+
+    it('omits ca_chain output when Vault does not return one', async () => {
+        const client = {
+            post: jest.fn().mockResolvedValue({
+                body: JSON.stringify({
+                    data: {
+                        certificate: 'cert',
+                        private_key: 'key',
+                        issuing_ca: 'ca',
+                        serial_number: '01:02',
+                    },
+                }),
+            }),
+        };
+
+        const results = await getCertificates([pkiRequest], client);
+
+        expect(results).toEqual([
+            expect.objectContaining({
+                request: expect.objectContaining({
+                    envVarName: 'TEST_CERT',
+                    outputVarName: 'test_cert',
+                }),
+                value: 'cert',
+            }),
+            expect.objectContaining({
+                request: expect.objectContaining({
+                    envVarName: 'TEST_KEY',
+                    outputVarName: 'test_key',
+                }),
+                value: 'key',
+            }),
+            expect.objectContaining({
+                request: expect.objectContaining({
+                    envVarName: 'TEST_CA',
+                    outputVarName: 'test_ca',
+                }),
+                value: 'ca',
+            }),
+        ]);
+    });
+
+    it('joins ca_chain output when Vault returns one', async () => {
+        const client = {
+            post: jest.fn().mockResolvedValue({
+                body: JSON.stringify({
+                    data: {
+                        certificate: 'cert',
+                        private_key: 'key',
+                        issuing_ca: 'ca',
+                        ca_chain: ['root', 'intermediate'],
+                        serial_number: '01:02',
+                    },
+                }),
+            }),
+        };
+
+        const results = await getCertificates([pkiRequest], client);
+
+        expect(results).toHaveLength(4);
+        expect(results[3]).toEqual(expect.objectContaining({
+            request: expect.objectContaining({
+                envVarName: 'TEST_CA_CHAIN',
+                outputVarName: 'test_ca_chain',
+            }),
+            value: 'root\nintermediate',
+        }));
+    });
+});


### PR DESCRIPTION
## Summary

Vault PKI responses do not always include ca_chain; the API marks it optional. vault-action currently calls .join() on that field unconditionally, which causes PKI certificate retrieval to fail after the certificate has already been issued.

This change skips only the optional ca_chain output when it is absent, while preserving the existing certificate, private key, and issuing CA outputs.

Closes #609.

## Tests

- npm test -- src/pki.test.js --runInBand
- npm test -- --runInBand
- npm run build