### PR TITLE
Make Severity configurable for `ignoreNotFound`

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,19 @@ When set to true, disables verification of server certificates when testing the 
 
 When set to true, prevents the action from failing when a secret does not exist.
 
+### `ignoreNotFoundSeverity`
+
+**Type: `string`**\
+**Default: `error`**
+
+Adjust the severity for messages produced by `ignoreNotFound`. Can be used to accept failure more silently.
+
+Supported values:
+
+- `error`: default, no change in behavior
+- `warning`: Warning annotation is added to the Workflow summary
+- `info`: No annotation is added to the Workflow summary
+
 ## Masking - Hiding Secrets from Logs
 
 This action uses GitHub Action's built-in masking, so all variables will automatically be masked (aka hidden) if printed to the console or to logs.

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,10 @@ inputs:
     description: 'Whether or not the action should exit successfully if some requested secrets were not found.'
     required: false
     default: 'false'
+  ignoreNotFoundSeverity:
+    description: 'The severity level of the log message when a secret is not found and ignoreNotFound is set to true. Supported values: info, warning, error'
+    required: false
+    default: 'error'
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -36,7 +36,7 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
     for (const secretRequest of secretRequests) {
         let { path, selector } = secretRequest;
 
-        // Strip leading slashes to avoid double-slash in the request path 
+        // Strip leading slashes to avoid double-slash in the request path
         // (e.g. /cubbyhole/test → v1/cubbyhole/test)
         const requestPath = `v1/${path.replace(/^\/+/, '')}`;
         let body;
@@ -55,7 +55,9 @@ async function getSecrets(secretRequests, client, ignoreNotFound) {
                     notFoundMsg = `Unable to retrieve result for "${path}" because it was not found: ${response.body.trim()}`;
                     const ignoreNotFound = (core.getInput('ignoreNotFound', { required: false }) || 'false').toLowerCase() != 'false';
                     if (ignoreNotFound) {
-                        core.error(`✘ ${notFoundMsg}`);
+                        const severity = (core.getInput('ignoreNotFoundSeverity', { required: false }) || 'error').toLowerCase();
+                        const logFn = { info: core.info, warning: core.warning, error: core.error }[severity] || core.error;
+                        logFn(`✘ ${notFoundMsg}`);
                         continue;
                     } else {
                         throw Error(notFoundMsg)


### PR DESCRIPTION
### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

We rely on vault-action a lot to fetch secrets used in Actions Workflows from Vault. We use a Structure in Vault based on a path taken from the `github.repository` which may or may not exist in Vault. For some of those paths we ignore failure using the `with.ignoreNotFound` (and it's fine). The paths which don't exist in Vault however cause an error annotation on the Workflow Summary.

The behavior was originally discussed in https://github.com/hashicorp/vault-action/pull/518 and I'd not want to challenge the "error" default but it causes some noise for us which this PR should address.

Setting `with.ignoreNotFoundSeverity` to `info` will silence those expected errors.


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/vault-action/blob/master/CHANGELOG.md) entry (only for user-facing changes)


### Community Note

* Please vote on this pull request by adding a 👍
  [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers
  prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request
  followers and do not help prioritize the request

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
